### PR TITLE
feat: add gate workflow to enforce dev→main PR flow

### DIFF
--- a/.github/workflows/called-gate-main-source.yml
+++ b/.github/workflows/called-gate-main-source.yml
@@ -1,0 +1,18 @@
+name: Gate — PR to main must come from dev
+
+on:
+  workflow_call:
+
+jobs:
+  check-source-branch:
+    name: Verify PR source is dev
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that PR to main comes from dev
+        run: |
+          if [ "${{ github.base_ref }}" = "main" ] && [ "${{ github.head_ref }}" != "dev" ]; then
+            echo "❌ PRs to main must come from 'dev', not '${{ github.head_ref }}'."
+            echo "   Workflow: feature/<name> → PR to dev → PR dev to main."
+            exit 1
+          fi
+          echo "✅ Source branch check passed (base: ${{ github.base_ref }}, head: ${{ github.head_ref }})"


### PR DESCRIPTION
## Changes
Adds `called-gate-main-source.yml` — a reusable workflow that fails if a PR targets `main` from any branch other than `dev`.

## How it works
- Called from each repo's CI workflow
- If `github.base_ref == main` and `github.head_ref != dev` → fails with a clear message
- If PR targets `dev` or PR to `main` comes from `dev` → passes

## How to wire it in each repo's CI
```yaml
gate-main-source:
  uses: wcmchenry3-stack/.github/.github/workflows/called-gate-main-source.yml@main
  secrets: inherit
```
This blocks the accidental feature→main PR pattern that caused the recent bypass.