### PR TITLE
fix: allow release/* branches to merge to main via gate

### DIFF
--- a/.github/workflows/called-gate-main-source.yml
+++ b/.github/workflows/called-gate-main-source.yml
@@ -8,11 +8,13 @@ jobs:
     name: Verify PR source is dev
     runs-on: ubuntu-latest
     steps:
-      - name: Check that PR to main comes from dev
+      - name: Check that PR to main comes from dev or release/*
         run: |
-          if [ "${{ github.base_ref }}" = "main" ] && [ "${{ github.head_ref }}" != "dev" ]; then
-            echo "❌ PRs to main must come from 'dev', not '${{ github.head_ref }}'."
+          head="${{ github.head_ref }}"
+          base="${{ github.base_ref }}"
+          if [ "$base" = "main" ] && [ "$head" != "dev" ] && [[ "$head" != release/* ]]; then
+            echo "❌ PRs to main must come from 'dev' or 'release/*', not '$head'."
             echo "   Workflow: feature/<name> → PR to dev → PR dev to main."
             exit 1
           fi
-          echo "✅ Source branch check passed (base: ${{ github.base_ref }}, head: ${{ github.head_ref }})"
+          echo "✅ Source branch check passed (base: $base, head: $head)"


### PR DESCRIPTION
Extends the gate check to allow `release/*` → `main` PRs in addition to `dev` → `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)