### PR TITLE
feat: add reusable perf workflows (Locust + Lighthouse CI)

### DIFF
--- a/.github/workflows/called-perf-backend.yml
+++ b/.github/workflows/called-perf-backend.yml
@@ -1,0 +1,89 @@
+name: Perf — Backend (Locust)
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        default: '.'
+      locustfile:
+        type: string
+        default: 'perf/locustfile.py'
+      thresholds-script:
+        type: string
+        default: 'perf/check_thresholds.py'
+      target-url:
+        type: string
+        required: true
+      users:
+        type: number
+        default: 10
+      run-time:
+        type: string
+        default: '60s'
+      spawn-rate:
+        type: number
+        default: 2
+      python-version:
+        type: string
+        default: '3.11'
+      locust-version:
+        type: string
+        default: '2.32.4'
+      # Space-separated user class names to run. Leave empty to run all.
+      user-classes:
+        type: string
+        default: ''
+      csv-prefix:
+        type: string
+        default: 'perf-results'
+      artifact-retention-days:
+        type: number
+        default: 30
+
+jobs:
+  backend-perf:
+    name: Backend load test (Locust)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: pip
+
+      - name: Install Locust
+        run: pip install locust==${{ inputs.locust-version }}
+
+      - name: Run Locust
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          locust -f ${{ inputs.locustfile }} \
+            --headless \
+            --users ${{ inputs.users }} \
+            --spawn-rate ${{ inputs.spawn-rate }} \
+            --run-time ${{ inputs.run-time }} \
+            --host "${{ inputs.target-url }}" \
+            --csv ${{ inputs.csv-prefix }} \
+            --exit-code-on-error 0 \
+            ${{ inputs.user-classes }}
+
+      - name: Check thresholds
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ -f "${{ inputs.thresholds-script }}" ]; then
+            python ${{ inputs.thresholds-script }} --csv ${{ inputs.csv-prefix }} || \
+              echo "::warning::Performance thresholds were breached. See artifacts for details."
+          else
+            echo "No threshold script found at ${{ inputs.thresholds-script }} — skipping check."
+          fi
+
+      - name: Upload Locust results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: locust-results-${{ github.run_id }}
+          path: ${{ inputs.working-directory }}/${{ inputs.csv-prefix }}*.csv
+          retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/workflows/called-perf-frontend.yml
+++ b/.github/workflows/called-perf-frontend.yml
@@ -1,0 +1,70 @@
+name: Perf — Frontend (Lighthouse CI)
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        default: '.'
+      build-command:
+        type: string
+        default: 'npx expo export --platform web'
+      dist-dir:
+        type: string
+        default: 'dist'
+      lhci-config:
+        type: string
+        default: 'lighthouserc.json'
+      node-version:
+        type: string
+        default: '20'
+      lhci-version:
+        type: string
+        default: '0.14.0'
+      artifact-retention-days:
+        type: number
+        default: 30
+    secrets:
+      # Pass any env vars the build command needs (e.g. EXPO_PUBLIC_API_URL).
+      BUILD_ENV:
+        required: false
+
+jobs:
+  frontend-perf:
+    name: Frontend performance (Lighthouse CI)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          BUILD_ENV: ${{ secrets.BUILD_ENV }}
+        run: ${{ inputs.build-command }}
+
+      - name: Run Lighthouse CI
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          npx @lhci/cli@${{ inputs.lhci-version }} autorun \
+            --collect.staticDistDir=${{ inputs.dist-dir }} \
+            --config=${{ inputs.lhci-config }}
+        continue-on-error: true
+
+      - name: Upload Lighthouse results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-results-${{ github.run_id }}
+          path: ${{ inputs.working-directory }}/.lighthouseci/
+          retention-days: ${{ inputs.artifact-retention-days }}


### PR DESCRIPTION
## Summary

Adds two reusable called workflows for performance testing across all projects in the stack.

### called-perf-backend.yml
Parametric Locust load test runner. Inputs:
- `target-url` — backend URL to test (required)
- `working-directory`, `locustfile`, `thresholds-script` — file paths
- `users`, `run-time`, `spawn-rate` — load parameters
- `user-classes` — space-separated class names (optional, runs all if empty)
- `python-version`, `locust-version`, `csv-prefix`, `artifact-retention-days`

### called-perf-frontend.yml
Parametric Lighthouse CI runner. Inputs:
- `working-directory`, `build-command`, `dist-dir`, `lhci-config` — file paths
- `node-version`, `lhci-version`, `artifact-retention-days`
- `BUILD_ENV` secret — passed to build step for env vars like `EXPO_PUBLIC_API_URL`

Both workflows use `continue-on-error: true` and upload artifacts for 30 days. Results are always informational — no merge gates.

## Usage example

\`\`\`yaml
backend-perf:
  uses: wcmchenry3-stack/.github/.github/workflows/called-perf-backend.yml@main
  with:
    working-directory: backend
    locustfile: perf/locustfile.py
    target-url: https://my-api.onrender.com
    users: 10
    run-time: 60s
    user-classes: LeaderboardUser

frontend-perf:
  uses: wcmchenry3-stack/.github/.github/workflows/called-perf-frontend.yml@main
  with:
    working-directory: frontend
    build-command: npx expo export --platform web
    dist-dir: dist
    lhci-config: lighthouserc.json
\`\`\`

## Test plan

- [ ] Merge this PR first (must be on `main` before consuming projects can reference `@main`)
- [ ] Then merge gaming_app PR #28 update that switches `perf.yml` to use these called workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)