### PR TITLE
feat: add ignore-vulns input to CVE scan workflow

### DIFF
--- a/.github/workflows/called-cve-python.yml
+++ b/.github/workflows/called-cve-python.yml
@@ -9,6 +9,10 @@ on:
       working-directory:
         type: string
         default: '.'
+      ignore-vulns:
+        type: string
+        default: ''
+        description: Space-separated CVE IDs to ignore (e.g. "CVE-2026-1234 CVE-2026-5678")
 
 jobs:
   cve-python:
@@ -22,5 +26,10 @@ jobs:
       - name: Install pip-audit
         run: pip install pip-audit
       - name: Run pip-audit
-        run: pip-audit -r requirements.txt
+        run: |
+          IGNORE_FLAGS=""
+          for id in ${{ inputs.ignore-vulns }}; do
+            IGNORE_FLAGS="$IGNORE_FLAGS --ignore-vuln $id"
+          done
+          pip-audit -r requirements.txt $IGNORE_FLAGS
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Summary

- Adds an optional `ignore-vulns` input (space-separated CVE IDs) to `called-cve-python.yml`
- When set, each ID is passed to `pip-audit` as `--ignore-vuln <ID>`
- Default is empty string — existing callers are unaffected
- Temporary ignores should be removed once a patched package version ships

## Motivation

`pygments` CVE-2026-4539 was filed against 2.19.2 (the current latest) with no fix version available yet. This blocks PRs in repos that depend on it transitively, with no actionable remediation. The ignore-vulns input lets individual repos declare known-unfixable CVEs explicitly rather than silently failing CI.

## Usage

```yaml
uses: wcmchenry3-stack/.github/.github/workflows/called-cve-python.yml@main
with:
  ignore-vulns: CVE-2026-4539
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)