### PR TITLE
feat: add OpenAI API policy validation workflow

### DIFF
--- a/.github/openai-policy-hashes.json
+++ b/.github/openai-policy-hashes.json
@@ -1,0 +1,14 @@
+{
+  "last_checked": "2025-03-27",
+  "note": "SHA-256 of stripped text content. 'uninitialized' triggers first-run issue and populates real hashes.",
+  "pages": {
+    "usage-policies": {
+      "url": "https://openai.com/policies/usage-policies",
+      "sha256": "uninitialized"
+    },
+    "terms-of-use": {
+      "url": "https://openai.com/policies/terms-of-use",
+      "sha256": "uninitialized"
+    }
+  }
+}

--- a/.github/workflows/called-openai-policy.yml
+++ b/.github/workflows/called-openai-policy.yml
@@ -1,0 +1,206 @@
+name: OpenAI API Policy Check
+
+# Validates that PR code touching the OpenAI API complies with:
+#   - OpenAI Usage Policies (no prohibited use, key hygiene)
+#   - OpenAI Terms of Use (rate limit handling, token caps)
+#
+# Policy references (calibrated against policy-version input):
+#   https://openai.com/policies/usage-policies
+#   https://openai.com/policies/terms-of-use
+#
+# Guard: restricted to repos listed in the allowed-repos input.
+# To add a new repo, append it (comma-separated) to allowed-repos
+# in the caller workflow — no changes needed here.
+
+on:
+  workflow_call:
+    inputs:
+      allowed-repos:
+        required: true
+        type: string
+        description: >
+          Comma-separated list of owner/repo values permitted to call
+          this workflow (e.g., wcmchenry3-stack/office_holder_cursor,
+          wcmchenry3-stack/book_app). The job fails immediately if
+          github.repository is not in this list.
+          To add a repo: append ,owner/new-repo to this input in the caller.
+      policy-version:
+        required: false
+        type: string
+        default: '2025-03-27'
+        description: >
+          ISO date of the OpenAI policy snapshot this workflow was
+          calibrated against. Surfaced in run logs so drift is visible.
+          Bump after reviewing policy pages post-update.
+
+jobs:
+  openai-policy-check:
+    name: OpenAI API Policy Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Guard — verify this repo is permitted to use OpenAI API
+        run: |
+          ALLOWED="${{ inputs.allowed-repos }}"
+          CURRENT="${{ github.repository }}"
+
+          if ! echo "$ALLOWED" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -qxF "$CURRENT"; then
+            echo "::error::OpenAI policy workflow is restricted to: $ALLOWED"
+            echo "::error::Current repo '$CURRENT' is not in the permitted list."
+            echo "::error::To add this repo, append it to allowed-repos in the caller workflow."
+            exit 1
+          fi
+          echo "Repo guard passed: $CURRENT"
+          echo "Policy snapshot date: ${{ inputs.policy-version }}"
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Identify changed files that reference OpenAI
+        id: find-openai
+        run: |
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" > changed_files.txt
+
+          echo "All changed files:"
+          cat changed_files.txt
+
+          # Filter to files that reference OpenAI API usage
+          > openai_files.txt
+          while IFS= read -r file; do
+            if [ -f "$file" ] && grep -qiE "(from openai|import openai|openai\.com|OpenAI\(|client\.chat\.completions|client\.completions\.create|OPENAI_API_KEY)" "$file"; then
+              echo "$file" >> openai_files.txt
+            fi
+          done < changed_files.txt
+
+          if [ ! -s openai_files.txt ]; then
+            echo "No changed files reference OpenAI — policy checks skipped."
+            echo "has_openai_files=false" >> "$GITHUB_OUTPUT"
+          else
+            echo ""
+            echo "Files with OpenAI references:"
+            cat openai_files.txt
+            echo "has_openai_files=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ---------------------------------------------------------------
+      # Check 1: API key not hardcoded
+      # OpenAI keys must come from environment variables, never from
+      # source. A leaked key = immediate quota abuse and account risk.
+      # https://platform.openai.com/docs/api-reference/authentication
+      # ---------------------------------------------------------------
+      - name: 'Check 1: API key not hardcoded'
+        if: steps.find-openai.outputs.has_openai_files == 'true'
+        run: |
+          FAIL=0
+          # Match literal sk- key patterns (real keys are sk-... or sk-proj-...)
+          KEY_PATTERN='sk-[a-zA-Z0-9\-_]{20,}'
+          # Match string-literal assignments to api_key / OPENAI_API_KEY variables
+          ASSIGN_PATTERN='(api_key|OPENAI_API_KEY)\s*=\s*["'"'"'][^"'"'"'$\{]{10,}'
+          while IFS= read -r file; do
+            if grep -qE "$KEY_PATTERN" "$file"; then
+              echo "::error file=$file::Possible hardcoded OpenAI API key (sk-...) detected. Store keys in environment variables and access via os.environ or process.env. See: https://platform.openai.com/docs/api-reference/authentication"
+              FAIL=1
+            fi
+            if grep -qE "$ASSIGN_PATTERN" "$file"; then
+              echo "::error file=$file::API key appears to be assigned from a string literal. Use an environment variable instead (e.g., api_key=os.environ['OPENAI_API_KEY']). See: https://platform.openai.com/docs/api-reference/authentication"
+              FAIL=1
+            fi
+          done < openai_files.txt
+          if [ "$FAIL" -eq 0 ]; then
+            echo "Check 1 passed: No hardcoded API key patterns detected."
+          fi
+          exit "$FAIL"
+
+      # ---------------------------------------------------------------
+      # Check 2: Rate limit / error handling present
+      # OpenAI enforces per-minute and per-day token limits. Unhandled
+      # 429 RateLimitErrors crash production and block all users.
+      # https://platform.openai.com/docs/guides/rate-limits
+      # ---------------------------------------------------------------
+      - name: 'Check 2: Rate limit / error handling present'
+        if: steps.find-openai.outputs.has_openai_files == 'true'
+        run: |
+          FAIL=0
+          RATE_PATTERNS="429|RateLimitError|rate_limit|retry|backoff|sleep|Retry|exponential|tenacity|httpx\.HTTPStatusError"
+          while IFS= read -r file; do
+            if ! grep -qE "$RATE_PATTERNS" "$file"; then
+              echo "::error file=$file::No rate-limit or retry handling found. OpenAI enforces token-per-minute limits; unhandled RateLimitError (HTTP 429) will crash production. Add retry/backoff logic. See: https://platform.openai.com/docs/guides/rate-limits"
+              FAIL=1
+            fi
+          done < openai_files.txt
+          if [ "$FAIL" -eq 0 ]; then
+            echo "Check 2 passed: Rate-limit handling found in all OpenAI-touching files."
+          fi
+          exit "$FAIL"
+
+      # ---------------------------------------------------------------
+      # Check 3: Model version pinned (warning only)
+      # Unversioned aliases (gpt-4o, gpt-4, o1) are silently updated
+      # by OpenAI — pinning to a dated version (gpt-4o-2024-11-20)
+      # prevents unexpected behavior changes between deploys.
+      # https://platform.openai.com/docs/models
+      # ---------------------------------------------------------------
+      - name: 'Check 3: Model version pinned (warning)'
+        if: steps.find-openai.outputs.has_openai_files == 'true'
+        run: |
+          # Match unversioned aliases: "gpt-4o", "gpt-4", "gpt-3.5-turbo", "o1", "o3", "o4-mini"
+          # A dated version like gpt-4o-2024-11-20 has -20\d\d- after the alias, so exclude those.
+          UNPINNED='["'"'"'](gpt-4o|gpt-4|gpt-3\.5-turbo|o1|o3|o4-mini|gpt-4-turbo)["'"'"']'
+          while IFS= read -r file; do
+            if grep -qE "$UNPINNED" "$file"; then
+              MATCHES=$(grep -nE "$UNPINNED" "$file" | head -5)
+              echo "::warning file=$file::Unversioned model alias detected. OpenAI silently updates these aliases — pin to a dated version (e.g., gpt-4o-2024-11-20) to prevent unexpected behavior changes. Matches: $MATCHES. See: https://platform.openai.com/docs/models"
+            fi
+          done < openai_files.txt
+          echo "Check 3 complete: model version warnings are informational — review pinning before release."
+
+      # ---------------------------------------------------------------
+      # Check 4: Token limit set (max_tokens / max_completion_tokens)
+      # Without a token cap, the API can return very large responses,
+      # exhausting quotas and causing unexpected cost spikes.
+      # https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens
+      # ---------------------------------------------------------------
+      - name: 'Check 4: Token limit set'
+        if: steps.find-openai.outputs.has_openai_files == 'true'
+        run: |
+          FAIL=0
+          TOKEN_PATTERNS="max_tokens|max_completion_tokens"
+          while IFS= read -r file; do
+            if ! grep -qE "$TOKEN_PATTERNS" "$file"; then
+              echo "::error file=$file::No token limit found (max_tokens or max_completion_tokens). Without a cap, large responses can exhaust your quota and cause unexpected cost spikes. See: https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens"
+              FAIL=1
+            fi
+          done < openai_files.txt
+          if [ "$FAIL" -eq 0 ]; then
+            echo "Check 4 passed: Token limit found in all OpenAI-touching files."
+          fi
+          exit "$FAIL"
+
+      # ---------------------------------------------------------------
+      # Summary — always runs so policy metadata is visible in every log
+      # ---------------------------------------------------------------
+      - name: Policy summary
+        if: always()
+        run: |
+          echo "========================================"
+          echo "  OpenAI API Policy Compliance Summary"
+          echo "========================================"
+          echo "  Policy snapshot date : ${{ inputs.policy-version }}"
+          echo "  Permitted repos      : ${{ inputs.allowed-repos }}"
+          echo ""
+          echo "  Policy references:"
+          echo "    Usage Policies : https://openai.com/policies/usage-policies"
+          echo "    Terms of Use   : https://openai.com/policies/terms-of-use"
+          echo "    Rate Limits    : https://platform.openai.com/docs/guides/rate-limits"
+          echo "    Models         : https://platform.openai.com/docs/models"
+          echo ""
+          echo "  To add a new permitted repo:"
+          echo "    Append ,owner/repo to allowed-repos in your caller workflow."
+          echo ""
+          echo "  To update after an OpenAI policy change:"
+          echo "    1. Review the policy pages above for new requirements"
+          echo "    2. Update grep patterns in called-openai-policy.yml if needed"
+          echo "    3. Bump policy-version default to today's date"
+          echo "    4. Open a PR to wcmchenry3-stack/.github"
+          echo "========================================"

--- a/.github/workflows/scheduled-openai-policy-check.yml
+++ b/.github/workflows/scheduled-openai-policy-check.yml
@@ -1,0 +1,193 @@
+name: Scheduled OpenAI Policy Check
+
+# Runs monthly to detect changes to the OpenAI policy pages that
+# called-openai-policy.yml is calibrated against. Uses SHA-256 hashes
+# of stripped page text (not raw HTML) to avoid false positives from
+# nav/footer/layout changes.
+#
+# On change detected: opens a GitHub issue with links and commits
+#   updated hashes to .github/openai-policy-hashes.json
+# On no change: logs a clean summary and exits
+#
+# Manual trigger: workflow_dispatch (use after known OpenAI announcements)
+
+on:
+  schedule:
+    - cron: '0 9 1 * *'   # 9 AM UTC on the 1st of every month
+  workflow_dispatch:
+
+permissions:
+  contents: write   # to commit updated hash baseline
+  issues: write     # to open alert issues
+
+jobs:
+  check-policy-hashes:
+    name: Check OpenAI Policy Page Hashes
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch and hash OpenAI policy pages
+        run: |
+          fetch_and_hash() {
+            local url="$1"
+            local outfile="$2"
+
+            # Fetch the page (follow redirects, fail on HTTP errors)
+            curl -sfL --max-time 30 "$url" > /tmp/raw_page.html
+
+            # Strip HTML to plain text using Python's built-in html.parser.
+            # We extract only <main> or <article> content when available to
+            # reduce noise from navigation and footer changes.
+            python3 - <<'PYEOF' > "$outfile"
+import sys
+from html.parser import HTMLParser
+
+class TextExtractor(HTMLParser):
+    SKIP_TAGS = {'script', 'style', 'nav', 'footer', 'header', 'noscript'}
+
+    def __init__(self):
+        super().__init__()
+        self.text = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self.SKIP_TAGS:
+            self._skip_depth += 1
+
+    def handle_endtag(self, tag):
+        if tag in self.SKIP_TAGS and self._skip_depth > 0:
+            self._skip_depth -= 1
+
+    def handle_data(self, data):
+        if self._skip_depth == 0:
+            stripped = data.strip()
+            if stripped:
+                self.text.append(stripped)
+
+with open('/tmp/raw_page.html', 'r', encoding='utf-8', errors='replace') as f:
+    html = f.read()
+
+parser = TextExtractor()
+parser.feed(html)
+print(' '.join(parser.text))
+PYEOF
+          }
+
+          fetch_and_hash "https://openai.com/policies/usage-policies" /tmp/usage_policies.txt
+          fetch_and_hash "https://openai.com/policies/terms-of-use"   /tmp/terms_of_use.txt
+
+          echo "usage_policies_hash=$(sha256sum /tmp/usage_policies.txt | cut -d' ' -f1)" >> "$GITHUB_ENV"
+          echo "terms_of_use_hash=$(sha256sum /tmp/terms_of_use.txt    | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+          echo "Current hashes:"
+          echo "  usage-policies : $usage_policies_hash"
+          echo "  terms-of-use   : $terms_of_use_hash"
+
+      - name: Compare hashes and detect changes
+        id: compare
+        run: |
+          BASELINE=".github/openai-policy-hashes.json"
+
+          STORED_USAGE=$(jq -r '.pages["usage-policies"].sha256' "$BASELINE")
+          STORED_TOU=$(jq -r '.pages["terms-of-use"].sha256'     "$BASELINE")
+
+          # Read current hashes from env (set by previous step via GITHUB_ENV)
+          CURRENT_USAGE="${usage_policies_hash}"
+          CURRENT_TOU="${terms_of_use_hash}"
+
+          echo "Stored hashes  — usage-policies: $STORED_USAGE | terms-of-use: $STORED_TOU"
+          echo "Current hashes — usage-policies: $CURRENT_USAGE | terms-of-use: $CURRENT_TOU"
+
+          CHANGES=""
+          if [ "$CURRENT_USAGE" != "$STORED_USAGE" ]; then
+            CHANGES="$CHANGES\n- **Usage Policies** — hash changed (was \`${STORED_USAGE:0:12}...\`, now \`${CURRENT_USAGE:0:12}...\`) — [review page](https://openai.com/policies/usage-policies)"
+          fi
+          if [ "$CURRENT_TOU" != "$STORED_TOU" ]; then
+            CHANGES="$CHANGES\n- **Terms of Use** — hash changed (was \`${STORED_TOU:0:12}...\`, now \`${CURRENT_TOU:0:12}...\`) — [review page](https://openai.com/policies/terms-of-use)"
+          fi
+
+          if [ -n "$CHANGES" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "$CHANGES" > /tmp/changes.txt
+            echo "Changes detected — will open issue."
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No policy changes detected."
+          fi
+
+      - name: Update baseline file
+        if: steps.compare.outputs.has_changes == 'true'
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          jq \
+            --arg date  "$TODAY" \
+            --arg usage "${usage_policies_hash}" \
+            --arg tou   "${terms_of_use_hash}" \
+            '.last_checked = $date |
+             .pages["usage-policies"].sha256 = $usage |
+             .pages["terms-of-use"].sha256 = $tou |
+             del(.note)' \
+            .github/openai-policy-hashes.json > /tmp/hashes-updated.json
+          mv /tmp/hashes-updated.json .github/openai-policy-hashes.json
+          echo "Baseline updated."
+
+      - name: Commit updated baseline
+        if: steps.compare.outputs.has_changes == 'true'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/openai-policy-hashes.json
+          git commit -m "chore: update OpenAI policy hash baseline [skip ci]"
+          git push
+
+      - name: Open GitHub issue for policy change
+        if: steps.compare.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CHANGES=$(cat /tmp/changes.txt)
+
+          if echo "$CHANGES" | grep -q "uninitialized"; then
+            TITLE="chore: OpenAI policy hash baseline initialized"
+          else
+            TITLE="action required: OpenAI policy pages updated — review called-openai-policy.yml"
+          fi
+
+          gh issue create \
+            --title "$TITLE" \
+            --body "$(cat <<EOF
+## OpenAI Policy Change Detected
+
+The following policy pages have new content hashes since the last check:
+
+$CHANGES
+
+## Required Actions
+
+1. Review the linked pages above for any new requirements
+2. Update grep patterns in \`.github/workflows/called-openai-policy.yml\` if needed
+3. Bump the \`policy-version\` default to today's date in that workflow
+4. Open a PR to this repo and close this issue once merged
+
+## Policy References
+- [Usage Policies](https://openai.com/policies/usage-policies)
+- [Terms of Use](https://openai.com/policies/terms-of-use)
+- [Rate Limits](https://platform.openai.com/docs/guides/rate-limits)
+- [Models](https://platform.openai.com/docs/models)
+
+---
+*Auto-opened by [scheduled-openai-policy-check](../../actions/workflows/scheduled-openai-policy-check.yml)*
+EOF
+)"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "========================================"
+          echo "  OpenAI Policy Check Complete"
+          echo "========================================"
+          echo "  Run date      : $(date -u +%Y-%m-%d)"
+          echo "  Changes found : ${{ steps.compare.outputs.has_changes }}"
+          echo "========================================"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ All workflows are prefixed `called-` and use `on: workflow_call`. Call them from
 | `called-deploy-render.yml` | Render deploy hook + ZAP post-deploy scan |
 | `called-zap-scheduled.yml` | ZAP baseline scan (caller owns the schedule) |
 | `called-wikipedia-policy.yml` | Wikimedia API compliance check — restricted to `office_holder_cursor` |
+| `called-openai-policy.yml` | OpenAI API compliance check — restricted to permitted repos (comma-separated list) |
 
 ## Caller Pattern
 
@@ -48,11 +49,12 @@ jobs:
 
 Some workflows are repo-scoped and will fail immediately if called from any other repository.
 
-| Workflow | Permitted repo | Reason |
-|----------|---------------|--------|
+| Workflow | Permitted repos | Reason |
+|----------|----------------|--------|
 | `called-wikipedia-policy.yml` | `wcmchenry3-stack/office_holder_cursor` | Only repo using the Wikimedia API |
+| `called-openai-policy.yml` | `wcmchenry3-stack/office_holder_cursor`, `wcmchenry3-stack/book_app` | Repos using the OpenAI API |
 
-**Caller pattern for `office_holder_cursor`:**
+**Caller pattern for `office_holder_cursor` (Wikipedia):**
 
 ```yaml
 jobs:
@@ -62,7 +64,19 @@ jobs:
       allowed-repo: 'wcmchenry3-stack/office_holder_cursor'
 ```
 
-A companion scheduled workflow (`scheduled-wikipedia-policy-check.yml`) runs on the 1st of each month to detect changes to the Wikimedia policy pages and opens a GitHub issue here if any revision IDs change. It can also be triggered manually via `workflow_dispatch`.
+**Caller pattern for OpenAI repos:**
+
+```yaml
+jobs:
+  openai-policy:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
+    with:
+      allowed-repos: 'wcmchenry3-stack/office_holder_cursor,wcmchenry3-stack/book_app'
+```
+
+To add a new OpenAI-using repo: append `,wcmchenry3-stack/new-repo` to `allowed-repos` in the caller — no changes needed to the workflow itself.
+
+Companion scheduled workflows run on the 1st of each month to detect policy page changes and open a GitHub issue here if updates are found. Both support `workflow_dispatch` for on-demand checks.
 
 ## Community Files
 


### PR DESCRIPTION
## Summary

- Adds `called-openai-policy.yml` — a multi-repo-guarded reusable PR validation workflow with 4 checks: no hardcoded API keys, rate-limit/error handling present, model version pinned (warning), and token limit set. Currently permitted for `office_holder_cursor` and `book_app`. Adding a new repo = one comma-append in the caller, no workflow changes needed.
- Adds `scheduled-openai-policy-check.yml` — monthly cron (+ `workflow_dispatch`) that fetches OpenAI policy pages, strips HTML to plain text using Python's built-in `html.parser`, SHA-256 hashes the content, and opens a GitHub issue here if hashes change.
- Adds `.github/openai-policy-hashes.json` — baseline hash store (initialized with `"uninitialized"`; first scheduled run populates real hashes and opens an init issue).
- Updates `README.md` restricted workflows table with both permitted repos and caller example.

## Caller pattern
```yaml
jobs:
  openai-policy:
    uses: wcmchenry3-stack/.github/.github/workflows/called-openai-policy.yml@main
    with:
      allowed-repos: 'wcmchenry3-stack/office_holder_cursor,wcmchenry3-stack/book_app'
```

## Test plan

- [ ] In `office_holder_cursor` or `book_app`, add the caller workflow and open a test PR with a hardcoded `sk-...` key → Check 1 fails
- [ ] Open a test PR with all 4 checks satisfied → all pass
- [ ] Call from an unlisted repo → Step 1 guard rejects with clear error listing permitted repos
- [ ] `workflow_dispatch` the scheduled check → initializes hashes, opens issue, commits baseline
- [ ] Set a stored hash to a fake value and re-run → detects change and opens issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)