### PR TITLE
fix(openai-policy): skip .env* files from OpenAI file detection

### DIFF
--- a/.github/workflows/called-openai-policy.yml
+++ b/.github/workflows/called-openai-policy.yml
@@ -51,6 +51,8 @@ jobs:
           # Filter to files that reference OpenAI API usage
           > openai_files.txt
           while IFS= read -r file; do
+            # Skip env/dotenv files - they declare variable names, not API logic
+            case "$(basename "$file")" in .env|.env.*|*.env) continue ;; esac
             if [ -f "$file" ] && grep -qiE "(from openai|import openai|openai\.com|OpenAI\(|client\.chat\.completions|client\.completions\.create|OPENAI_API_KEY)" "$file"; then
               echo "$file" >> openai_files.txt
             fi


### PR DESCRIPTION
## Problem
`.env.example` and similar dotenv files contain `OPENAI_API_KEY=` as a variable declaration, which caused the OpenAI file scanner to flag them as "files with OpenAI references". They then failed:
- **Check 2** (rate-limit handling) — no retry logic in an env file
- **Check 4** (token limit) — no `max_tokens` in an env file

Surfaced in wcmchenry3-stack/book_app#115 where adding `SENTRY_DSN=` to `.env.example` made it a changed file and triggered the false positive.

## Fix
Skip files whose basename matches `.env`, `.env.*`, or `*.env` before the grep filter. These files declare variable names, not API logic.

## Test plan
- [ ] Merge this, then re-run CI on book_app#115 — `openai-policy` check should pass
- [ ] Confirm a PR that actually changes OpenAI service code still triggers the checks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)