### PR TITLE
feat(ci): add backend health + Expo compat workflows

### DIFF
--- a/.github/workflows/called-backend-health.yml
+++ b/.github/workflows/called-backend-health.yml
@@ -1,0 +1,52 @@
+name: Backend Health Check
+
+on:
+  workflow_call:
+    inputs:
+      backend-url:
+        description: 'Base URL of the deployed backend (e.g. https://yahtzee-api.onrender.com)'
+        type: string
+        required: true
+      health-path:
+        description: 'Health endpoint path'
+        type: string
+        default: '/health'
+      probe-path:
+        description: 'Secondary endpoint to probe (verifies routing is live)'
+        type: string
+        default: ''
+      probe-expected-status:
+        description: 'Expected HTTP status from probe endpoint (e.g. 400, 401, 404)'
+        type: string
+        default: '400'
+
+jobs:
+  backend-health:
+    name: Backend Health
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check backend health endpoint
+        run: |
+          URL="${{ inputs.backend-url }}${{ inputs.health-path }}"
+          echo "Checking $URL ..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$URL")
+          echo "Backend returned: $STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Backend health check failed (HTTP $STATUS)"
+            exit 1
+          fi
+          echo "Backend is healthy"
+
+      - name: Probe secondary endpoint
+        if: inputs.probe-path != ''
+        run: |
+          URL="${{ inputs.backend-url }}${{ inputs.probe-path }}"
+          EXPECTED="${{ inputs.probe-expected-status }}"
+          echo "Probing $URL (expect HTTP $EXPECTED) ..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$URL")
+          echo "Probe returned: $STATUS"
+          if [ "$STATUS" != "$EXPECTED" ]; then
+            echo "::error::Probe endpoint returned unexpected status: $STATUS (expected $EXPECTED)"
+            exit 1
+          fi
+          echo "Probe endpoint is live (returned $STATUS as expected)"

--- a/.github/workflows/called-expo-compat.yml
+++ b/.github/workflows/called-expo-compat.yml
@@ -1,0 +1,43 @@
+name: Expo Dependency Compatibility
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Directory containing the Expo project (with package.json)'
+        type: string
+        default: '.'
+      node-version:
+        description: 'Node.js version'
+        type: string
+        default: '20'
+
+jobs:
+  expo-compat:
+    name: Expo Compatibility Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ${{ inputs.working-directory }}
+
+      - name: Check Expo SDK compatibility
+        run: |
+          echo "Checking dependency compatibility with Expo SDK..."
+          npx expo install --check 2>&1 | tee /tmp/expo-check.log
+          EXIT_CODE=${PIPESTATUS[0]}
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo ""
+            echo "::error::Expo dependency compatibility check failed. Run 'npx expo install --fix' locally to resolve."
+            exit 1
+          fi
+          echo "All dependencies are compatible with the installed Expo SDK"
+        working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Summary
- Add `called-backend-health.yml` — reusable workflow that validates a backend's health endpoint is reachable and optionally probes a secondary endpoint (e.g., confirming routing is live)
- Add `called-expo-compat.yml` — reusable workflow that runs `npx expo install --check` to catch SDK-incompatible dependency versions before they ship

## Context
These are the first two checks from the [CI Validation Plan](https://github.com/wcmchenry3-stack/.github/issues/9), derived from lessons learned during the gaming_app iOS white screen saga (PRs #77-#98):
- **Backend health** (Issue #9): ensures the deployed backend is reachable on every PR
- **Expo compat** (Issue #16): would have prevented the Sentry 8.x / Expo SDK 55 incompatibility that caused 6+ PRs of debugging

## Applies To
- `gaming_app` (consuming PR: wcmchenry3-stack/gaming_app — pending)
- `book_app` (future)

## Test plan
- [ ] Merge this PR first (gaming_app CI references `@main`)
- [ ] Verify workflows are syntactically valid (GitHub Actions will validate on first call)
- [ ] Merge gaming_app PR to trigger both new checks
- [ ] Confirm backend-health passes (yahtzee-api.onrender.com/health returns 200)
- [ ] Confirm expo-compat passes (all deps compatible with current Expo SDK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)