### PR TITLE
feat(ci): add reusable Sentry check workflow

### DIFF
--- a/.github/workflows/called-sentry-check.yml
+++ b/.github/workflows/called-sentry-check.yml
@@ -1,0 +1,48 @@
+name: Sentry Integration Check
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Directory containing the Python backend'
+        type: string
+        default: 'backend'
+      python-version:
+        type: string
+        default: '3.11'
+      test-class:
+        description: 'Pytest class or marker to run (e.g. TestSentryUnit)'
+        type: string
+        default: 'tests/test_sentry.py'
+    secrets:
+      SENTRY_DSN:
+        required: true
+
+jobs:
+  sentry-check:
+    name: Sentry Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          if [ -f requirements-dev.txt ]; then
+            pip install -r requirements-dev.txt
+          else
+            pip install -r requirements.txt
+          fi
+
+      - name: Run Sentry tests
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          ENVIRONMENT: test
+        run: |
+          pytest ${{ inputs.test-class }} -v --tb=short


### PR DESCRIPTION
## Summary
- Add `called-sentry-check.yml` — reusable workflow that runs Sentry integration tests on every PR

## Context
Phase 4 of the [CI Validation Plan](https://github.com/wcmchenry3-stack/.github/issues/12). During the gaming_app iOS white screen saga (PRs #91-#96), Sentry silently failed because its native module was incompatible with Expo SDK 55. The SDK swallowed init crashes with try/catch, so no one noticed error reporting was broken.

## Applies To
- `gaming_app` (consuming PR: wcmchenry3-stack/gaming_app — pending)
- `book_app` (future)

## Test plan
- [ ] Merge this PR first
- [ ] Merge gaming_app consuming PR to trigger the check
- [ ] Confirm sentry-check job runs and passes with SENTRY_DSN secret set

🤖 Generated with [Claude Code](https://claude.com/claude-code)