### PR TITLE
feat(ci): add env validation + local path detection workflows

### DIFF
--- a/.github/workflows/called-env-validation.yml
+++ b/.github/workflows/called-env-validation.yml
@@ -1,0 +1,37 @@
+name: Required Environment Variable Validation
+
+on:
+  workflow_call:
+    inputs:
+      required-vars:
+        description: 'Comma-separated list of required env var names (e.g. SENTRY_DSN,EXPO_PUBLIC_API_URL)'
+        type: string
+        required: true
+      context-label:
+        description: 'Human-readable label for error messages (e.g. "backend deploy")'
+        type: string
+        default: 'this workflow'
+
+jobs:
+  env-validation:
+    name: Env Var Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate required environment variables
+        run: |
+          MISSING=""
+          IFS=',' read -ra VARS <<< "${{ inputs.required-vars }}"
+          for var in "${VARS[@]}"; do
+            var=$(echo "$var" | xargs)  # trim whitespace
+            if [ -z "${!var}" ]; then
+              MISSING="$MISSING  - $var\n"
+            fi
+          done
+          if [ -n "$MISSING" ]; then
+            echo "::error::Missing required environment variables for ${{ inputs.context-label }}:"
+            echo -e "$MISSING"
+            echo ""
+            echo "Add these in: repo Settings > Secrets and variables > Actions"
+            exit 1
+          fi
+          echo "All required environment variables are set"

--- a/.github/workflows/called-local-path-check.yml
+++ b/.github/workflows/called-local-path-check.yml
@@ -1,0 +1,78 @@
+name: Local Path Detection
+
+on:
+  workflow_call:
+    inputs:
+      scan-paths:
+        description: 'Space-separated paths to scan for local machine paths (e.g. "ios/ android/")'
+        type: string
+        default: 'ios/'
+      file-patterns:
+        description: 'Grep include patterns (e.g. "*.xcconfig,*.pbxproj")'
+        type: string
+        default: '*.xcconfig,*.pbxproj'
+      extra-patterns:
+        description: 'Additional regex patterns to flag (comma-separated, e.g. "/home/,/opt/local/")'
+        type: string
+        default: ''
+
+jobs:
+  local-path-check:
+    name: Local Path Detection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for hardcoded local machine paths
+        run: |
+          FOUND=0
+          SCAN_PATHS="${{ inputs.scan-paths }}"
+
+          # Build grep include flags
+          INCLUDES=""
+          IFS=',' read -ra PATTERNS <<< "${{ inputs.file-patterns }}"
+          for p in "${PATTERNS[@]}"; do
+            p=$(echo "$p" | xargs)
+            INCLUDES="$INCLUDES --include=$p"
+          done
+
+          # Default patterns: /Users/ and /home/ (common local dev paths)
+          SEARCH_PATTERNS="/Users/|/home/"
+
+          # Add extra patterns if provided
+          EXTRA="${{ inputs.extra-patterns }}"
+          if [ -n "$EXTRA" ]; then
+            IFS=',' read -ra EXTRA_PATS <<< "$EXTRA"
+            for ep in "${EXTRA_PATS[@]}"; do
+              ep=$(echo "$ep" | xargs)
+              SEARCH_PATTERNS="$SEARCH_PATTERNS|$ep"
+            done
+          fi
+
+          echo "Scanning: $SCAN_PATHS"
+          echo "Patterns: $SEARCH_PATTERNS"
+          echo "File types: ${{ inputs.file-patterns }}"
+          echo "---"
+
+          for dir in $SCAN_PATHS; do
+            if [ ! -d "$dir" ]; then
+              echo "Skipping $dir (not found)"
+              continue
+            fi
+            MATCHES=$(grep -rn $INCLUDES -E "$SEARCH_PATTERNS" "$dir" 2>/dev/null || true)
+            if [ -n "$MATCHES" ]; then
+              echo "::error::Found hardcoded local paths in $dir:"
+              echo "$MATCHES" | head -20
+              FOUND=1
+            fi
+          done
+
+          if [ "$FOUND" -eq 1 ]; then
+            echo ""
+            echo "Committed files contain paths from a local dev machine."
+            echo "These will break on CI runners and other developers' machines."
+            echo "Fix: regenerate these files on a clean environment or remove local paths."
+            exit 1
+          fi
+
+          echo "No hardcoded local paths found"


### PR DESCRIPTION
## Summary
- Add `called-env-validation.yml` — fails fast when required env vars are missing, with clear error message
- Add `called-local-path-check.yml` — scans committed files for hardcoded local machine paths (/Users/, /home/)

## Context
Lessons learned from gaming_app PRs #77-#98:
- **Issue #17**: PR #88 — Sentry DSN was missing from CI, causing silent failures. This workflow catches missing env vars immediately.
- **Issue #18**: PR #87 — Committed `ios/Pods/` had hardcoded `/Users/bill.mchenry/...` paths that broke Xcode Cloud. This workflow detects them.

## Applies To
- `gaming_app` (consuming PR pending)
- `book_app` (future)
- All org repos (env validation)

## Test plan
- [ ] Merge this PR first
- [ ] Merge gaming_app consuming PR
- [ ] Confirm local-path-check runs on PRs with ios/ changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)