### PR TITLE
feat(ci): add iOS build check + Claude failure analysis

### DIFF
--- a/.github/workflows/called-claude-failure-analysis.yml
+++ b/.github/workflows/called-claude-failure-analysis.yml
@@ -1,0 +1,80 @@
+name: Claude Failure Analysis
+
+on:
+  workflow_call:
+    inputs:
+      log-paths:
+        description: 'Space-separated paths to log files to include in analysis'
+        type: string
+        default: ''
+      context:
+        description: 'What was being tested (e.g. "iOS Xcode build", "Sentry integration tests")'
+        type: string
+        required: true
+      max-log-lines:
+        description: 'Maximum number of log lines to send to Claude'
+        type: number
+        default: 200
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: true
+
+jobs:
+  analyze:
+    name: Claude Analysis
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Collect logs
+        id: logs
+        run: |
+          LOG_CONTENT=""
+          for path in ${{ inputs.log-paths }}; do
+            if [ -f "$path" ]; then
+              LOG_CONTENT="$LOG_CONTENT\n--- $path ---\n$(head -${{ inputs.max-log-lines }} "$path")"
+            fi
+          done
+          if [ -z "$LOG_CONTENT" ]; then
+            LOG_CONTENT="No log files found at specified paths."
+          fi
+          # Write to file to avoid shell escaping issues
+          echo "$LOG_CONTENT" > /tmp/ci-logs.txt
+
+      - name: Analyze with Claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY not set — skipping Claude analysis"
+            exit 0
+          fi
+
+          LOGS=$(cat /tmp/ci-logs.txt | head -${{ inputs.max-log-lines }})
+          ESCAPED_LOGS=$(echo "$LOGS" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
+
+          ANALYSIS=$(curl -s https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "{
+              \"model\": \"claude-sonnet-4-5-20241022\",
+              \"max_tokens\": 1024,
+              \"messages\": [{
+                \"role\": \"user\",
+                \"content\": \"A CI job for ${{ inputs.context }} failed. Here are the logs:\\n\\n$ESCAPED_LOGS\\n\\nBriefly explain what went wrong and suggest a fix. Be concise.\"
+              }]
+            }" | python3 -c "import sys,json; print(json.load(sys.stdin).get('content',[{}])[0].get('text','Analysis unavailable'))" 2>/dev/null || echo "Claude API call failed")
+
+          if [ -n "${{ github.event.pull_request.number }}" ]; then
+            gh pr comment "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" \
+              --body "## CI Failure Analysis (${{ inputs.context }})
+
+          $ANALYSIS
+
+          ---
+          *Automated analysis by Claude*"
+          else
+            echo "::notice::$ANALYSIS"
+          fi

--- a/.github/workflows/called-ios-build-check.yml
+++ b/.github/workflows/called-ios-build-check.yml
@@ -1,0 +1,79 @@
+name: iOS Xcode Build Check
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Directory containing the iOS project (parent of ios/)'
+        type: string
+        default: '.'
+      workspace-name:
+        description: 'Xcode workspace name (e.g. GamingApp.xcworkspace)'
+        type: string
+        required: true
+      scheme:
+        description: 'Xcode scheme name (e.g. GamingApp)'
+        type: string
+        required: true
+      node-version:
+        description: 'Node.js version for npm ci'
+        type: string
+        default: '20'
+    secrets:
+      EXPO_PUBLIC_API_URL:
+        required: false
+
+jobs:
+  xcode-build:
+    name: Xcode Build (no signing)
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Install CocoaPods
+        run: |
+          cd ios
+          rm -f Podfile.lock
+          for attempt in 1 2 3; do
+            echo "=== pod install attempt $attempt ==="
+            if pod install; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::pod install failed after 3 attempts"
+              exit 1
+            fi
+            sleep 10
+          done
+
+      - name: Xcode build (no signing, no simulator)
+        run: |
+          xcodebuild build \
+            -workspace ios/${{ inputs.workspace-name }} \
+            -scheme ${{ inputs.scheme }} \
+            -configuration Debug \
+            -destination generic/platform=iOS \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty --color
+        env:
+          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xcode-build-logs
+          path: ~/Library/Logs/DiagnosticReports/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Add `called-ios-build-check.yml` — validates Xcode project compiles on macOS runner with `CODE_SIGNING_ALLOWED=NO`
- Add `called-claude-failure-analysis.yml` — reusable workflow that sends failure logs to Claude API and posts analysis as PR comment

## Context
- **Phase 5** (Issue #13): Catches Xcode build failures before expensive simulator runs or Xcode Cloud builds. Uses committed `ios/` directory (no `expo prebuild`). Includes pod install with retry.
- **Bonus** (Issue #20): Any workflow can call this on failure to get AI-powered analysis posted as a PR comment. Gracefully skips if `ANTHROPIC_API_KEY` is not configured.

## Applies To
- `gaming_app`, `book_app` (iOS build check)
- All repos (Claude failure analysis)

## Test plan
- [ ] Merge this PR
- [ ] Merge gaming_app consuming PR to trigger iOS build check
- [ ] Verify xcodebuild runs and passes on macOS runner
- [ ] (Optional) Test Claude analysis by intentionally breaking a build

🤖 Generated with [Claude Code](https://claude.com/claude-code)