### PR TITLE
feat(ci): add iOS simulator + Android emulator E2E workflows

### DIFF
--- a/.github/workflows/called-android-e2e.yml
+++ b/.github/workflows/called-android-e2e.yml
@@ -1,0 +1,81 @@
+name: Android Build + E2E
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Directory containing the Expo/RN project (parent of android/)'
+        type: string
+        default: '.'
+      maestro-flow:
+        description: 'Path to Maestro flow YAML (relative to repo root)'
+        type: string
+        required: true
+      node-version:
+        type: string
+        default: '20'
+      java-version:
+        type: string
+        default: '17'
+    secrets:
+      EXPO_PUBLIC_API_URL:
+        required: false
+
+jobs:
+  android-e2e:
+    name: Android Build + E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ inputs.java-version }}
+          distribution: temurin
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Generate native Android project
+        run: npx expo prebuild --platform android --clean
+        env:
+          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
+
+      - name: Gradle build (debug)
+        run: cd android && ./gradlew assembleDebug --no-daemon
+        env:
+          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+        working-directory: .
+
+      - name: Run Android emulator + Maestro
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          arch: x86_64
+          script: |
+            adb install ${{ inputs.working-directory }}/android/app/build/outputs/apk/debug/app-debug.apk
+            sleep 5
+            maestro test ${{ inputs.maestro-flow }}
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-e2e-failure
+          path: ~/.maestro/tests/
+          retention-days: 7

--- a/.github/workflows/called-ios-e2e.yml
+++ b/.github/workflows/called-ios-e2e.yml
@@ -1,0 +1,110 @@
+name: iOS Simulator E2E
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Directory containing the Expo/RN project (parent of ios/)'
+        type: string
+        default: '.'
+      workspace-name:
+        description: 'Xcode workspace name (e.g. GamingApp.xcworkspace)'
+        type: string
+        required: true
+      scheme:
+        description: 'Xcode scheme name (e.g. GamingApp)'
+        type: string
+        required: true
+      maestro-flow:
+        description: 'Path to Maestro flow YAML (relative to repo root)'
+        type: string
+        required: true
+      node-version:
+        type: string
+        default: '20'
+    secrets:
+      EXPO_PUBLIC_API_URL:
+        required: false
+
+jobs:
+  ios-e2e:
+    name: iOS Simulator E2E
+    runs-on: macos-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Install CocoaPods
+        run: |
+          cd ios
+          rm -f Podfile.lock
+          for attempt in 1 2 3; do
+            echo "=== pod install attempt $attempt ==="
+            if pod install; then break; fi
+            [ "$attempt" -eq 3 ] && exit 1
+            sleep 10
+          done
+
+      - name: Build for simulator
+        run: |
+          xcodebuild build \
+            -workspace ios/${{ inputs.workspace-name }} \
+            -scheme ${{ inputs.scheme }} \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 15,OS=latest' \
+            CODE_SIGNING_ALLOWED=NO \
+            CONFIGURATION_BUILD_DIR=$PWD/build/ios \
+            | xcpretty
+        env:
+          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
+
+      - name: Boot simulator
+        run: |
+          UDID=$(xcrun simctl list devices available | grep "iPhone 15" | head -1 | grep -E -o '[0-9A-F-]{36}')
+          xcrun simctl boot "$UDID"
+          xcrun simctl bootstatus "$UDID" -b
+
+      - name: Install app on simulator
+        run: |
+          APP_PATH=$(find build/ios -name "*.app" -type d | head -1)
+          UDID=$(xcrun simctl list devices booted | grep -E -o '[0-9A-F-]{36}' | head -1)
+          xcrun simctl install "$UDID" "$APP_PATH"
+
+      - name: Start Metro bundler
+        run: npx expo start --no-dev --minify &
+        env:
+          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
+
+      - name: Wait for Metro
+        run: sleep 15
+
+      - name: Run Maestro E2E
+        run: maestro test ${{ inputs.maestro-flow }}
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-e2e-failure
+          path: |
+            ~/.maestro/tests/
+            maestro-*.png
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Add `called-ios-e2e.yml` — builds app for iOS simulator, boots iPhone 15, runs Maestro E2E flow
- Add `called-android-e2e.yml` — runs `expo prebuild`, Gradle debug build, Android emulator + Maestro E2E

## Context
- **Phase 6** (Issue #14): Full iOS E2E on simulator — the check that would have caught the white screen on day one
- **Phase 7** (Issue #15): Android build + emulator E2E — same pattern, cheaper Linux runner

## Features
- Pod install with 3x retry logic
- `npm ci` for lockfile integrity
- 30-minute timeout
- Failure artifacts (screenshots, Maestro logs) uploaded
- Configurable inputs: workspace, scheme, Maestro flow path, node/java versions

## Applies To
- `gaming_app` (bundle ID: `com.buffingchi.games`)
- `book_app` (bundle ID: `com.buffingchi.bookshelf`)

## Test plan
- [ ] Merge this PR
- [ ] Merge gaming_app consuming PR (Maestro flow files)
- [ ] Trigger iOS E2E manually or via PR to validate simulator boots and app renders
- [ ] Trigger Android E2E to validate emulator + Maestro

🤖 Generated with [Claude Code](https://claude.com/claude-code)