### PR TITLE
fix(ci): make SENTRY_DSN optional in sentry-check

### DIFF
--- a/.github/workflows/called-sentry-check.yml
+++ b/.github/workflows/called-sentry-check.yml
@@ -16,7 +16,7 @@ on:
         default: 'tests/test_sentry.py'
     secrets:
       SENTRY_DSN:
-        required: true
+        required: false
 
 jobs:
   sentry-check:


### PR DESCRIPTION
## Summary
Change SENTRY_DSN from `required: true` to `required: false` in called-sentry-check.yml. The test file already handles a missing DSN by skipping the format validation test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)