### PR TITLE
fix(ci): disable coverage threshold in sentry-check

### DIFF
--- a/.github/workflows/called-sentry-check.yml
+++ b/.github/workflows/called-sentry-check.yml
@@ -45,4 +45,4 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           ENVIRONMENT: test
         run: |
-          pytest ${{ inputs.test-class }} -v --tb=short
+          pytest ${{ inputs.test-class }} -v --tb=short --no-cov -o "addopts="


### PR DESCRIPTION
Override addopts with --no-cov to prevent the calling repo's pyproject.toml coverage threshold from failing when running only the sentry test file.