### PR TITLE
fix(ci): properly override addopts in sentry-check

### DIFF
--- a/.github/workflows/called-sentry-check.yml
+++ b/.github/workflows/called-sentry-check.yml
@@ -45,4 +45,4 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           ENVIRONMENT: test
         run: |
-          pytest ${{ inputs.test-class }} -v --tb=short --no-cov -o "addopts="
+          pytest ${{ inputs.test-class }} -v --tb=short --override-ini="addopts="


### PR DESCRIPTION
Use --override-ini="addopts=" to properly clear coverage flags from pyproject.toml.