### PR TITLE
feat: add Android Gradle build check reusable workflow

### DIFF
--- a/.github/workflows/called-android-build-check.yml
+++ b/.github/workflows/called-android-build-check.yml
@@ -1,0 +1,78 @@
+name: Android Gradle Build Check
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Directory containing the Android project (parent of android/)'
+        type: string
+        default: '.'
+      node-version:
+        description: 'Node.js version for npm ci'
+        type: string
+        default: '22'
+      java-version:
+        description: 'JDK version for Gradle'
+        type: string
+        default: '17'
+    secrets:
+      EXPO_PUBLIC_API_URL:
+        required: false
+
+jobs:
+  gradle-build:
+    name: Gradle Build (Debug)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: npm
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.java-version }}
+
+      - name: Install JS dependencies
+        run: npm ci
+
+      - name: Gradle cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/gradle-wrapper.properties', '**/build.gradle', '**/settings.gradle') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Build Debug APK
+        working-directory: ${{ inputs.working-directory }}/android
+        run: ./gradlew assembleDebug --no-daemon -x lint -PreactNativeArchitectures=x86_64
+        env:
+          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
+
+      - name: Validate APK exists
+        working-directory: ${{ inputs.working-directory }}/android
+        run: |
+          APK_PATH=$(find app/build/outputs/apk/debug -name '*.apk' | head -1)
+          if [ -z "$APK_PATH" ]; then
+            echo "::error::Debug APK was not produced — Gradle build failed silently"
+            exit 1
+          fi
+          APK_SIZE=$(stat --printf="%s" "$APK_PATH")
+          echo "Debug APK built successfully: $APK_PATH (${APK_SIZE} bytes)"
+
+      - name: Upload build reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-build-reports
+          path: ${{ inputs.working-directory }}/android/app/build/reports/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Adds `called-android-build-check.yml` reusable workflow mirroring `called-ios-build-check.yml` for Android
- Runs `./gradlew assembleDebug` on ubuntu-latest with JDK 17, Node 22, Gradle caching
- Limits to x86_64 architecture in CI for speed (compilation validation only)
- Validates APK output exists, uploads build reports on failure
- Used by both `book_app` and `gaming_app` repos

## Test plan
- [ ] Verify workflow syntax is valid (GitHub Actions will parse on PR)
- [ ] Merge, then trigger from book_app CI to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)