### PR TITLE
feat(policy): add org-level enforcement toggle for OpenAI/Gemini

### DIFF
--- a/.github/policy-enforcement.yml
+++ b/.github/policy-enforcement.yml
@@ -1,0 +1,27 @@
+# Org-wide enforcement control for API policy workflows.
+#
+# Each called-*-policy.yml workflow reads this file and decides whether
+# findings block the PR (required) or are informational-only (advisory).
+#
+# Violations are ALWAYS annotated in the PR UI as ::error or ::warning.
+# This file only controls whether those findings *fail the check*.
+#
+# Change values here to roll out enforcement across the org without
+# editing each repo individually. Flip a repo to `required` once it
+# actually starts calling the API in question.
+#
+# Scope: applies to policy workflows that run org-wide and rely on
+# grep-based detection (openai, gemini). Wikipedia uses an allowed-repo
+# guard at the workflow level, so it is not listed here.
+
+defaults:
+  openai: advisory
+  gemini: advisory
+
+# Per-repo overrides. Uncomment and set to `required` when the repo
+# begins calling the API. Repo key is the bare repo name (no owner).
+overrides: {}
+  # book_app:
+  #   openai: required
+  # office_holder_cursor:
+  #   gemini: required

--- a/.github/workflows/called-gemini-policy.yml
+++ b/.github/workflows/called-gemini-policy.yml
@@ -54,6 +54,8 @@ jobs:
           while IFS= read -r file; do
             # Skip env/dotenv files
             case "$(basename "$file")" in .env|.env.*|*.env) continue ;; esac
+            # Skip .claude/ policy/config files — they name APIs as detection patterns, not callers
+            case "$file" in .claude/*) continue ;; esac
             if [ -f "$file" ] && grep -qiE "(from google import genai|from google\.genai|google-genai|google\.generativeai|generativelanguage\.googleapis|generate_content|genai\.Client)" "$file"; then
               echo "$file" >> gemini_files.txt
             fi
@@ -68,6 +70,27 @@ jobs:
             cat gemini_files.txt
             echo "has_gemini_files=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # ---------------------------------------------------------------
+      # Load org-wide enforcement mode for Gemini policy.
+      # The config lives in .github/policy-enforcement.yml of this repo.
+      # When mode == "required", violations fail the check.
+      # When mode == "advisory" (default), violations are annotated only.
+      # ---------------------------------------------------------------
+      - name: Load enforcement mode
+        id: enforce
+        run: |
+          CONFIG_URL="https://raw.githubusercontent.com/wcmchenry3-stack/.github/main/.github/policy-enforcement.yml"
+          if ! curl -sfL "$CONFIG_URL" -o /tmp/policy-enforcement.yml; then
+            echo "::warning::Could not fetch policy-enforcement.yml — defaulting to advisory"
+            echo "mode=advisory" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          MODE=$(yq ".overrides.\"${REPO_NAME}\".gemini // .defaults.gemini // \"advisory\"" /tmp/policy-enforcement.yml)
+          if [ -z "$MODE" ] || [ "$MODE" = "null" ]; then MODE="advisory"; fi
+          echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Gemini policy enforcement mode for ${REPO_NAME}: ${MODE}"
 
       # ---------------------------------------------------------------
       # Check 1: API key not hardcoded
@@ -95,6 +118,9 @@ jobs:
           done < gemini_files.txt
           if [ "$FAIL" -eq 0 ]; then
             echo "Check 1 passed: No hardcoded API key patterns detected."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 1 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
           fi
           exit "$FAIL"
 
@@ -117,6 +143,9 @@ jobs:
           done < gemini_files.txt
           if [ "$FAIL" -eq 0 ]; then
             echo "Check 2 passed: Rate-limit handling found in all Gemini-touching files."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 2 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
           fi
           exit "$FAIL"
 
@@ -142,6 +171,9 @@ jobs:
           done < gemini_files.txt
           if [ "$FAIL" -eq 0 ]; then
             echo "Check 3 passed: Token limit found in all files calling generate_content."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 3 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
           fi
           exit "$FAIL"
 
@@ -172,6 +204,7 @@ jobs:
           echo "========================================"
           echo "  Policy snapshot date : ${{ inputs.policy-version }}"
           echo "  Repo                 : ${{ github.repository }}"
+          echo "  Enforcement mode     : ${{ steps.enforce.outputs.mode }}"
           echo ""
           echo "  Policy references:"
           echo "    Terms of Service   : https://ai.google.dev/gemini-api/terms"

--- a/.github/workflows/called-openai-policy.yml
+++ b/.github/workflows/called-openai-policy.yml
@@ -71,6 +71,27 @@ jobs:
           fi
 
       # ---------------------------------------------------------------
+      # Load org-wide enforcement mode for OpenAI policy.
+      # The config lives in .github/policy-enforcement.yml of this repo.
+      # When mode == "required", violations fail the check.
+      # When mode == "advisory" (default), violations are annotated only.
+      # ---------------------------------------------------------------
+      - name: Load enforcement mode
+        id: enforce
+        run: |
+          CONFIG_URL="https://raw.githubusercontent.com/wcmchenry3-stack/.github/main/.github/policy-enforcement.yml"
+          if ! curl -sfL "$CONFIG_URL" -o /tmp/policy-enforcement.yml; then
+            echo "::warning::Could not fetch policy-enforcement.yml — defaulting to advisory"
+            echo "mode=advisory" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          MODE=$(yq ".overrides.\"${REPO_NAME}\".openai // .defaults.openai // \"advisory\"" /tmp/policy-enforcement.yml)
+          if [ -z "$MODE" ] || [ "$MODE" = "null" ]; then MODE="advisory"; fi
+          echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
+          echo "::notice::OpenAI policy enforcement mode for ${REPO_NAME}: ${MODE}"
+
+      # ---------------------------------------------------------------
       # Check 1: API key not hardcoded
       # OpenAI keys must come from environment variables, never from
       # source. A leaked key = immediate quota abuse and account risk.
@@ -96,6 +117,9 @@ jobs:
           done < openai_files.txt
           if [ "$FAIL" -eq 0 ]; then
             echo "Check 1 passed: No hardcoded API key patterns detected."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 1 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
           fi
           exit "$FAIL"
 
@@ -118,6 +142,9 @@ jobs:
           done < openai_files.txt
           if [ "$FAIL" -eq 0 ]; then
             echo "Check 2 passed: Rate-limit handling found in all OpenAI-touching files."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 2 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
           fi
           exit "$FAIL"
 
@@ -161,6 +188,9 @@ jobs:
           done < openai_files.txt
           if [ "$FAIL" -eq 0 ]; then
             echo "Check 4 passed: Token limit found in all OpenAI-touching files."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 4 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
           fi
           exit "$FAIL"
 
@@ -175,6 +205,7 @@ jobs:
           echo "========================================"
           echo "  Policy snapshot date : ${{ inputs.policy-version }}"
           echo "  Repo                 : ${{ github.repository }}"
+          echo "  Enforcement mode     : ${{ steps.enforce.outputs.mode }}"
           echo ""
           echo "  Policy references:"
           echo "    Usage Policies : https://openai.com/policies/usage-policies"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,23 @@ A `PreToolUse` hook gates every `gh pr create` call behind a policy check.
 
 **Current policies:** OpenAI, Wikipedia/Wikimedia, Google Gemini.
 
+## Org-level policy enforcement (`policy-enforcement.yml`)
+
+`called-openai-policy.yml` and `called-gemini-policy.yml` read
+`.github/policy-enforcement.yml` from this meta-repo at job start to
+decide whether violations **fail the check** or are **advisory only**.
+
+**The model:**
+- Individual repos *inherit* the policy scaffolding (agents, hooks, `.claude/policies/`).
+- The org (this repo) *controls* whether findings block PRs.
+
+Defaults are `advisory` — violations are annotated in the PR UI but do not
+fail the check. Flip a repo's key to `required` in
+`overrides:` once it actually starts calling the API in question.
+
+Wikipedia uses a stricter model (`allowed-repo:` input gate) and is not
+listed in `policy-enforcement.yml`.
+
 ## Conventions
 
 - Workflows are prefixed `called-` and use `workflow_call` triggers.


### PR DESCRIPTION
## Summary

Introduces **`.github/policy-enforcement.yml`** as the single source of truth for whether API-policy findings block PRs across the org.

The model: individual repos *inherit* the policy scaffolding (`.claude/policies/`, hooks, agents). The org (this repo) *controls* whether findings are blocking. No per-repo workflow edits needed to roll enforcement in or out.

## How it works

`called-openai-policy.yml` and `called-gemini-policy.yml` each read `policy-enforcement.yml` at job start:

- `mode: required` → violations fail the check (old behavior)
- `mode: advisory` → violations annotated in PR UI but do not fail the check (new default)

Lookup order: `overrides.<repo>.<policy>` → `defaults.<policy>` → `advisory`.

Violations are **always** annotated as `::error` / `::warning` regardless of mode — enforcement only controls the final exit code.

## Changes

- **NEW** `.github/policy-enforcement.yml` — org-level config, all defaults `advisory`
- `called-openai-policy.yml` — new `Load enforcement mode` step + conditional exits in checks 1/2/4
- `called-gemini-policy.yml` — same wiring + mirrors the `.claude/*` detection exclusion from wcmchenry3-stack/.github@617a865
- `CLAUDE.md` — documents the enforcement model

## Why this matters right now

Six PRs across `wcm_portfolio_site`, `buffingchi_site`, `powerplayshistory_site` propagate the policy scaffolding into repos that don't actually use OpenAI/Gemini yet. Without this toggle they'd be stuck failing `openai-policy / OpenAI API Policy Check` even though the repos hold no API-calling code.

## Flipping a repo to `required`

Edit `.github/policy-enforcement.yml`:

```yaml
overrides:
  book_app:
    openai: required
```

No repo-side changes needed.

## Test plan

- [ ] Workflow YAML validates (confirmed locally with ruby YAML.load_file)
- [ ] Re-run checks on the 6 downstream PRs after merge — openai-policy should pass (advisory mode)
- [ ] Confirm `::notice::` line with enforcement mode appears in workflow logs
- [ ] Simulate `required` by flipping one override to verify blocking still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)