### PR TITLE
feat(backend-health): send identifying User-Agent on curl probes

### DIFF
--- a/.github/workflows/called-backend-health.yml
+++ b/.github/workflows/called-backend-health.yml
@@ -19,6 +19,10 @@ on:
         description: 'Expected HTTP status from probe endpoint (e.g. 400, 401, 404)'
         type: string
         default: '400'
+      user-agent:
+        description: 'User-Agent header to send. Default identifies the check so Cloudflare / WAFs can allowlist it; raw curl UA is often blocked.'
+        type: string
+        default: 'github-actions-backend-health-check/1.0'
 
 jobs:
   backend-health:
@@ -29,7 +33,8 @@ jobs:
         run: |
           URL="${{ inputs.backend-url }}${{ inputs.health-path }}"
           echo "Checking $URL ..."
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$URL")
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+            -A "${{ inputs.user-agent }}" "$URL")
           echo "Backend returned: $STATUS"
           if [ "$STATUS" != "200" ]; then
             echo "::error::Backend health check failed (HTTP $STATUS)"
@@ -43,7 +48,8 @@ jobs:
           URL="${{ inputs.backend-url }}${{ inputs.probe-path }}"
           EXPECTED="${{ inputs.probe-expected-status }}"
           echo "Probing $URL (expect HTTP $EXPECTED) ..."
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$URL")
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+            -A "${{ inputs.user-agent }}" "$URL")
           echo "Probe returned: $STATUS"
           if [ "$STATUS" != "$EXPECTED" ]; then
             echo "::error::Probe endpoint returned unexpected status: $STATUS (expected $EXPECTED)"


### PR DESCRIPTION
## Summary
Cloudflare and similar WAFs default-block requests with curl's raw \`User-Agent\` from known cloud provider IP ranges (GitHub Actions runners in particular). The reusable \`backend-health\` check returns 403 for endpoints fronted by such WAFs even when the backend is fine, turning PR CI red for no actionable reason.

Add an optional \`user-agent\` input (default \`github-actions-backend-health-check/1.0\`) and pass it via \`curl -A\` on both the primary health check and the secondary probe step. Consumer repos can override via \`with: user-agent: ...\` if they want a custom identifier, or allowlist this default in their WAF.

## Context
Surfaced on wcmchenry3-stack/book_app#183 — the bookshelf repo's backend-health check was returning 403 from GitHub Actions runners while the same URL returned 200 from dev machines. Response headers showed \`server: cloudflare\`, confirming Cloudflare was terminating the block.

## Compatibility
Non-breaking: new input is optional with a default. Existing consumer repos will pick up the new UA automatically on next run with no changes required.

## Test plan
- [x] Default value is set — existing consumer workflows continue to work without changes
- [ ] Merge + confirm bookshelf's \`backend-health\` check goes green on wcmchenry3-stack/book_app#182 (currently red with the same 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)