### PR TITLE
feat(backend-health): support X-Health-Probe shared-secret header

### DIFF
--- a/.github/workflows/called-backend-health.yml
+++ b/.github/workflows/called-backend-health.yml
@@ -23,18 +23,31 @@ on:
         description: 'User-Agent header to send. Default identifies the check so Cloudflare / WAFs can allowlist it; raw curl UA is often blocked.'
         type: string
         default: 'github-actions-backend-health-check/1.0'
+    # Consumer repos that need to bypass a WAF on /health should:
+    #   1. Store a secret named BACKEND_HEALTH_PROBE_TOKEN in the repo/org
+    #   2. Call this workflow with `secrets: inherit`
+    #   3. Create a WAF custom rule allowlisting X-Health-Probe == <token> on /health
+    # When the secret is absent (most consumers), no header is sent and the
+    # behavior is identical to before. See wcmchenry3-stack/book_app#183.
 
 jobs:
   backend-health:
     name: Backend Health
     runs-on: ubuntu-latest
+    env:
+      PROBE_TOKEN: ${{ secrets.BACKEND_HEALTH_PROBE_TOKEN }}
     steps:
       - name: Check backend health endpoint
         run: |
           URL="${{ inputs.backend-url }}${{ inputs.health-path }}"
           echo "Checking $URL ..."
+          HEADER_ARG=()
+          if [ -n "$PROBE_TOKEN" ]; then
+            HEADER_ARG=(-H "X-Health-Probe: $PROBE_TOKEN")
+            echo "Sending X-Health-Probe header (token configured)"
+          fi
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
-            -A "${{ inputs.user-agent }}" "$URL")
+            -A "${{ inputs.user-agent }}" "${HEADER_ARG[@]}" "$URL")
           echo "Backend returned: $STATUS"
           if [ "$STATUS" != "200" ]; then
             echo "::error::Backend health check failed (HTTP $STATUS)"
@@ -48,8 +61,12 @@ jobs:
           URL="${{ inputs.backend-url }}${{ inputs.probe-path }}"
           EXPECTED="${{ inputs.probe-expected-status }}"
           echo "Probing $URL (expect HTTP $EXPECTED) ..."
+          HEADER_ARG=()
+          if [ -n "$PROBE_TOKEN" ]; then
+            HEADER_ARG=(-H "X-Health-Probe: $PROBE_TOKEN")
+          fi
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
-            -A "${{ inputs.user-agent }}" "$URL")
+            -A "${{ inputs.user-agent }}" "${HEADER_ARG[@]}" "$URL")
           echo "Probe returned: $STATUS"
           if [ "$STATUS" != "$EXPECTED" ]; then
             echo "::error::Probe endpoint returned unexpected status: $STATUS (expected $EXPECTED)"


### PR DESCRIPTION
## Summary
Adds optional \`X-Health-Probe\` header support to the reusable backend-health check so consumer repos can pair it with a scoped Cloudflare/WAF custom rule that allowlists requests by secret header on the health path — avoiding IP allowlisting (GHA runner IPs rotate across Azure ranges) and UA spoofing (dishonest, fragile, set a bad precedent — see the earlier #43 which we closed).

When the env-derived \`PROBE_TOKEN\` is set, curl sends \`-H \"X-Health-Probe: <token>\"\` on both the primary check and the secondary probe step. When unset, no header is sent — backwards compatible with all existing consumers.

## Consumer contract
1. Store a secret named \`BACKEND_HEALTH_PROBE_TOKEN\` in the repo/org secrets
2. Call this workflow with \`secrets: inherit\` (most repos do this already)
3. Create a WAF custom rule allowlisting \`X-Health-Probe == <token>\` scoped to the health path

When the secret is absent, behavior is identical to before the change.

## Context
Paired with a Cloudflare WAF custom rule on the bookshelf zone (already created) that matches \`http.request.uri.path eq \"/health\"\` AND an exact \`X-Health-Probe\` header value, and \"skips\" Bot Fight Mode + managed WAF + rate limit for those requests. Scoped rule = narrow blast radius.

Closes wcmchenry3-stack/book_app#183.

## Test plan
- [x] Cloudflare rule created and verified active (zone: buffingchi.com)
- [x] GH secret \`BACKEND_HEALTH_PROBE_TOKEN\` stored in wcmchenry3-stack/book_app
- [ ] After merge, bookshelf's backend-health check on wcmchenry3-stack/book_app#182 returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)