### PR TITLE
fix: restore optional service-id input and fix ZAP scan validation

### DIFF
--- a/.github/workflows/called-deploy-render.yml
+++ b/.github/workflows/called-deploy-render.yml
@@ -7,6 +7,10 @@ on:
         description: 'Human-readable service name used in artifact naming'
         type: string
         required: true
+      service-id:
+        description: 'Render service ID (overrides RENDER_SERVICE_ID secret; required for repos that deploy multiple services)'
+        type: string
+        required: false
       zap-target-url:
         description: 'Live URL to run ZAP baseline scan against after deploy'
         type: string
@@ -15,7 +19,7 @@ on:
       RENDER_API_KEY:
         required: true
       RENDER_SERVICE_ID:
-        required: true
+        required: false
 
 jobs:
   deploy:
@@ -25,8 +29,9 @@ jobs:
       - name: Trigger Render deploy
         id: trigger
         run: |
+          service_id="${{ inputs.service-id || secrets.RENDER_SERVICE_ID }}"
           response=$(curl -s -w "\n%{http_code}" -X POST \
-            "https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys" \
+            "https://api.render.com/v1/services/${service_id}/deploys" \
             -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{"clearCache":"do_not_clear"}')
@@ -40,7 +45,7 @@ jobs:
       - name: Wait for deploy to complete
         run: |
           deploy_id="${{ steps.trigger.outputs.deploy_id }}"
-          service_id="${{ secrets.RENDER_SERVICE_ID }}"
+          service_id="${{ inputs.service-id || secrets.RENDER_SERVICE_ID }}"
           echo "Polling deploy $deploy_id ..."
           for i in $(seq 1 20); do
             sleep 30

--- a/.github/workflows/called-zap-scheduled.yml
+++ b/.github/workflows/called-zap-scheduled.yml
@@ -6,7 +6,8 @@ on:
       target-url:
         description: 'URL to scan'
         type: string
-        required: true
+        required: false
+        default: ''
       artifact-name:
         description: 'Name for the uploaded ZAP report artifact'
         type: string
@@ -22,13 +23,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run ZAP baseline scan
+        if: ${{ inputs.target-url != '' }}
         uses: zaproxy/action-baseline@v0.15.0
         with:
           target: ${{ inputs.target-url }}
           fail_action: false
       - name: Upload ZAP report
         uses: actions/upload-artifact@v4
-        if: always()
+        if: ${{ inputs.target-url != '' }}
         with:
           name: ${{ inputs.artifact-name }}-${{ github.run_id }}
           path: report_html.html


### PR DESCRIPTION
## Summary
- **`called-deploy-render.yml`**: PR #54 moved `service-id` to a secret, but `gaming_app` deploys two services with different IDs — requiring the same secret name for both jobs isn't possible. Restores `service-id` as an optional input that overrides `RENDER_SERVICE_ID` secret, so single-service repos use the secret and multi-service repos pass the ID as an input. Also marks `RENDER_SERVICE_ID` secret as `required: false` (single-service repos with the secret still work; multi-service repos supply the ID via input).
- **`called-zap-scheduled.yml`**: Makes `target-url` optional (empty string default) and guards the ZAP scan + upload steps with `if: inputs.target-url != ''`. Prevents the workflow file validation failures that occurred when callers passed `${{ secrets.SITE_URL }}` in `with:` (secret expressions evaluate to empty string at parse time, failing required-input validation on every push).

## Related PRs in calling repos
- wcmchenry3-stack/gaming_app#305 — hardcode ZAP URL
- wcmchenry3-stack/office_holder_cursor#402 — remove service-id input + hardcode ZAP URL
- wcmchenry3-stack/powerplayshistory_site#22 — hardcode ZAP URL

## Action required before merging calling-repo PRs
- `office_holder_cursor`: set repo secret `RENDER_SERVICE_ID=srv-d6ubbu24d50c73cpmgkg`
- `powerplayshistory_site`: set repo secret `RENDER_SERVICE_ID` to the correct service ID

## Test plan
- [ ] gaming_app deploy still works (passes service-id as input override)
- [ ] office_holder_cursor deploy works using RENDER_SERVICE_ID secret
- [ ] ZAP scan does not fire file-validation failures on push

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)