### PR TITLE
feat: canonical community-health files + org-wide sync workflow

### DIFF
--- a/.github/workflows/sync-community-health.yml
+++ b/.github/workflows/sync-community-health.yml
@@ -1,0 +1,173 @@
+name: Sync Community Health Files
+
+# Runs whenever the canonical community-health/ files change on main, or on
+# manual dispatch. Opens a PR in each target repo when content differs.
+#
+# Required secret: COMMUNITY_HEALTH_SYNC_PAT
+#   Fine-grained PAT with Contents: write + Pull requests: write on all repos
+#   listed in the matrix below. A classic PAT with `repo` scope also works.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'community-health/**'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Open PRs even if files are already up-to-date'
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    name: Sync → ${{ matrix.repo }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - gaming_app
+          - office_holder_cursor
+          - book_app
+          - powerplayshistory_site
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync files to ${{ matrix.repo }}
+        env:
+          GH_TOKEN: ${{ secrets.COMMUNITY_HEALTH_SYNC_PAT }}
+          REPO: wcmchenry3-stack/${{ matrix.repo }}
+          FORCE: ${{ inputs.force || 'false' }}
+        run: |
+          python3 - << 'PYEOF'
+          import os, json, base64, urllib.request, urllib.error, sys
+
+          REPO    = os.environ['REPO']
+          TOKEN   = os.environ['GH_TOKEN']
+          FORCE   = os.environ.get('FORCE', 'false').lower() == 'true'
+          BRANCH  = 'chore/sync-community-health'
+          API     = 'https://api.github.com'
+
+          FILE_MAP = {
+              'community-health/SECURITY.md':
+                  'SECURITY.md',
+              'community-health/PULL_REQUEST_TEMPLATE.md':
+                  '.github/PULL_REQUEST_TEMPLATE.md',
+              'community-health/ISSUE_TEMPLATE/bug_report.md':
+                  '.github/ISSUE_TEMPLATE/bug_report.md',
+              'community-health/ISSUE_TEMPLATE/feature_request.md':
+                  '.github/ISSUE_TEMPLATE/feature_request.md',
+          }
+
+          def api(path, method='GET', body=None):
+              url = f'{API}{path}'
+              data = json.dumps(body).encode() if body is not None else None
+              req = urllib.request.Request(url, data=data, method=method)
+              req.add_header('Authorization', f'Bearer {TOKEN}')
+              req.add_header('Accept', 'application/vnd.github+json')
+              req.add_header('X-GitHub-Api-Version', '2022-11-28')
+              if data:
+                  req.add_header('Content-Type', 'application/json')
+              try:
+                  with urllib.request.urlopen(req) as r:
+                      return {} if r.status == 204 else json.loads(r.read())
+              except urllib.error.HTTPError as e:
+                  if e.code == 404:
+                      return None
+                  msg = e.read().decode()
+                  print(f'  HTTP {e.code} {method} {path}: {msg}', file=sys.stderr)
+                  sys.exit(1)
+
+          # -- Resolve default branch -----------------------------------------
+          repo_info     = api(f'/repos/{REPO}')
+          default_branch = repo_info['default_branch']
+          print(f'{REPO} (default branch: {default_branch})')
+
+          # -- Diff each file ---------------------------------------------------
+          needs_update = []
+          for src, dest in FILE_MAP.items():
+              new_content = open(src).read()
+              current     = api(f'/repos/{REPO}/contents/{dest}?ref={default_branch}')
+              if current is None:
+                  print(f'  {dest}: missing → will add')
+                  needs_update.append((src, dest, new_content))
+              else:
+                  existing = base64.b64decode(
+                      current['content'].replace('\n', '')
+                  ).decode()
+                  if new_content != existing or FORCE:
+                      print(f'  {dest}: differs → will update')
+                      needs_update.append((src, dest, new_content))
+                  else:
+                      print(f'  {dest}: up-to-date')
+
+          if not needs_update:
+              print('  Nothing to sync.')
+              sys.exit(0)
+
+          # -- Guard against duplicate open PRs ---------------------------------
+          open_prs = api(
+              f'/repos/{REPO}/pulls'
+              f'?state=open&head=wcmchenry3-stack:{BRANCH}'
+          )
+          if open_prs:
+              print(f'  Open sync PR already exists — skipping.')
+              sys.exit(0)
+
+          # -- Reset sync branch ------------------------------------------------
+          stale = api(f'/repos/{REPO}/git/refs/heads/{BRANCH}')
+          if stale:
+              api(f'/repos/{REPO}/git/refs/heads/{BRANCH}', method='DELETE')
+              print(f'  Removed stale branch.')
+
+          base_sha = api(
+              f'/repos/{REPO}/git/refs/heads/{default_branch}'
+          )['object']['sha']
+
+          api(f'/repos/{REPO}/git/refs', method='POST', body={
+              'ref': f'refs/heads/{BRANCH}',
+              'sha': base_sha,
+          })
+          print(f'  Created branch {BRANCH}.')
+
+          # -- Commit each file -------------------------------------------------
+          for src, dest, content in needs_update:
+              encoded      = base64.b64encode(content.encode()).decode()
+              on_branch    = api(f'/repos/{REPO}/contents/{dest}?ref={BRANCH}')
+              commit_body  = {
+                  'message': 'chore: sync community health files from org template',
+                  'content': encoded,
+                  'branch':  BRANCH,
+              }
+              if on_branch:
+                  commit_body['sha'] = on_branch['sha']
+              api(f'/repos/{REPO}/contents/{dest}', method='PUT', body=commit_body)
+              print(f'  Committed {dest}')
+
+          # -- Open PR ----------------------------------------------------------
+          pr_body = (
+              'Automated sync of community health files from '
+              '`wcmchenry3-stack/.github`.\n\n'
+              '## Files synced\n'
+              '- `SECURITY.md`\n'
+              '- `.github/PULL_REQUEST_TEMPLATE.md`\n'
+              '- `.github/ISSUE_TEMPLATE/bug_report.md`\n'
+              '- `.github/ISSUE_TEMPLATE/feature_request.md`\n\n'
+              '_Auto-generated by `sync-community-health.yml`. '
+              'Review and merge to apply the update._'
+          )
+
+          pr = api(f'/repos/{REPO}/pulls', method='POST', body={
+              'title': 'chore: sync community health files from org template',
+              'head':  BRANCH,
+              'base':  default_branch,
+              'body':  pr_body,
+          })
+          if pr:
+              print(f'  PR opened: {pr["html_url"]}')
+          else:
+              print('  Failed to open PR.', file=sys.stderr)
+              sys.exit(1)
+          PYEOF

--- a/community-health/ISSUE_TEMPLATE/bug_report.md
+++ b/community-health/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report a bug
+labels: bug
+---
+
+## Description
+<!-- Clear, concise description of the bug -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behaviour
+
+## Actual behaviour
+
+## Environment
+- OS:
+- Browser / runtime:
+- Version / branch:
+
+## Logs / screenshots
+<!-- Paste relevant logs or attach screenshots -->

--- a/community-health/ISSUE_TEMPLATE/feature_request.md
+++ b/community-health/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Problem statement
+<!-- What problem does this solve? Who is affected? -->
+
+## Proposed solution
+<!-- How would you solve it? -->
+
+## Alternatives considered
+<!-- What other approaches did you consider and why did you reject them? -->
+
+## Acceptance criteria
+- [ ]
+- [ ]

--- a/community-health/PULL_REQUEST_TEMPLATE.md
+++ b/community-health/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## Summary
+<!-- What does this PR do? Focus on the why, not the how. -->
+-
+
+## Type of change
+- [ ] `feat` — new feature or behaviour
+- [ ] `fix` — bug fix
+- [ ] `chore` — tooling, deps, config
+- [ ] `test` — adding or updating tests
+- [ ] `docs` — documentation only
+- [ ] `refactor` — code change that is neither fix nor feature
+- [ ] `ci` — CI/CD changes
+- [ ] `a11y` — accessibility improvement
+- [ ] `security` — security hardening
+
+## Testing done
+<!-- What did you run? Any coverage delta? -->
+- [ ] All tests pass locally
+- [ ] No new lint errors
+
+## Security checklist
+- [ ] No secrets committed (gitleaks passes)
+- [ ] Dependencies reviewed if new ones added
+- [ ] OWASP considerations addressed if auth or data handling was touched
+
+## Accessibility checklist *(web / frontend PRs only)*
+- [ ] axe DevTools — no violations on affected pages
+- [ ] Keyboard navigation tested
+- [ ] Tested at 320px viewport width
+- [ ] Tested at 200% zoom
+
+## Mobile checklist *(iOS / Android PRs only)*
+- [ ] Tested on iOS Simulator or physical device
+- [ ] `ios-build-check` / `android-build-check` CI job passes
+- [ ] No hardcoded local paths in `.pbxproj` (`local-path-check` passes)
+- [ ] `pod install` run locally and `Podfile.lock` changes committed (if applicable)

--- a/community-health/SECURITY.md
+++ b/community-health/SECURITY.md
@@ -1,0 +1,93 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release on `main` is actively maintained and receives security updates.
+
+| Branch | Supported |
+|--------|-----------|
+| `main` (latest) | Yes |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report privately via [GitHub's private vulnerability reporting](https://github.com/wcmchenry3-stack) or email the maintainer directly (see GitHub profile for contact details).
+
+**Include in your report:**
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact assessment
+- Any suggested mitigations (optional)
+
+**Response timeline:**
+- Acknowledgement within **48 hours**
+- Status update within **7 days**
+- Fix or mitigation plan within **30 days** for confirmed vulnerabilities
+
+## Disclosure Policy
+
+- Vulnerabilities will be remediated before public disclosure.
+- Reporters will be credited in release notes (unless they prefer anonymity).
+- We follow a **90-day coordinated disclosure** timeline.
+
+## Automated Security Controls
+
+Every pull request is gated on the following automated checks:
+
+| Check | Tool | What it catches |
+|-------|------|----------------|
+| SAST | Bandit | Python code security issues (injection, insecure patterns) |
+| SCA — Python | pip-audit | Known CVEs in Python dependencies |
+| SCA — Frontend | npm audit | Known CVEs in Node / Expo dependencies |
+| Secret scanning | GitHub Secret Scanning + Gitleaks | Credentials committed to source |
+| DAST (post-deploy) | OWASP ZAP | Live application vulnerabilities (XSS, SQLi, etc.) |
+| DAST (weekly) | OWASP ZAP active scan | Ongoing penetration testing against deployed services |
+
+*Not every check applies to every project — mobile-only repos skip frontend npm audit; static sites skip Python checks. All checks are listed here so the full posture is visible even when a given check is not yet wired up.*
+
+## Security Architecture
+
+### Authentication & Authorisation
+- RS256 JWT with Google OAuth 2.0; refresh token rotation with JTI revocation
+- Role-based access control enforced server-side on every endpoint; no client-side trust
+
+### Database
+- SQLAlchemy ORM only — no raw SQL anywhere in the codebase
+- All queries use parameterised values; string interpolation into queries is rejected in review
+- Database credentials loaded exclusively from environment variables; never committed
+
+### Rate Limiting
+- Per-user (authenticated) and per-IP (unauthenticated) limits via slowapi
+- Every public endpoint is throttled — no unprotected routes
+- Authenticated routes key by user ID; unauthenticated routes key by IP
+
+### Input Validation & Injection Prevention
+- All user input validated at the API boundary before any processing
+- File uploads: extension, MIME type, size, and magic-bytes validation before storage or processing
+- No `shell=True` in subprocess calls; no dynamic SQL string construction
+
+### Security Headers
+- `Content-Security-Policy` (CSP)
+- `Strict-Transport-Security` (HSTS) — enforced in production
+- `X-Frame-Options: DENY`
+- `X-Content-Type-Options: nosniff`
+- `Permissions-Policy`
+- `Referrer-Policy`
+
+### CORS
+- Explicit origin allowlist; wildcard origins (`*`) rejected at configuration validation time
+- Credentials not permitted with wildcard origins
+
+### Mobile (iOS & Android)
+- No secrets, API keys, or credentials bundled in the app binary
+- All credentials resolved via authenticated server-side endpoints
+- `PrivacyInfo.xcprivacy` maintained and kept current for App Store compliance
+- Certificate pinning evaluated on each release for sensitive endpoints
+- Privacy manifest reviewed before each App Store / Google Play submission
+
+### Secrets Management
+- All secrets stored in environment variables or GitHub Actions secrets — never in source
+- `.env` files are gitignored and never committed
+- Gitleaks pre-commit and CI scan enforced on every push


### PR DESCRIPTION
## Summary
- Adds `community-health/` as the single source of truth for org-wide community health files (`SECURITY.md`, PR template, issue templates). Comprehensive `SECURITY.md` covers all security controls and architecture — intentionally lists items not yet applicable to every repo so the full posture is always visible.
- Adds `sync-community-health.yml` — triggers on `main` push when `community-health/**` changes. Matrix job per target repo: diffs each file against the repo's default branch and opens a `chore/sync-community-health` PR when any file differs. Skips repos already up-to-date and de-dupes PRs (won't open a second one if one's already open).

## Action required before merging
Set the `COMMUNITY_HEALTH_SYNC_PAT` org secret (or repo secret on this repo):
- **Fine-grained PAT** with **Contents: write** + **Pull requests: write** on `gaming_app`, `office_holder_cursor`, `book_app`, `powerplayshistory_site`
- A classic PAT with `repo` scope also works

Once this PR merges, the workflow fires automatically and opens sync PRs in all four repos.

## Target repos
`gaming_app` · `office_holder_cursor` · `book_app` · `powerplayshistory_site`

## Test plan
- [ ] `COMMUNITY_HEALTH_SYNC_PAT` secret is set
- [ ] Merge this PR → workflow triggers → sync PRs open in all four repos
- [ ] Edit a line in `community-health/SECURITY.md` → push → new sync PRs appear in repos where content differs
- [ ] Re-run with `force: true` via `workflow_dispatch` → PRs open even for up-to-date repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)