### PR TITLE
ci: bump actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/called-cve-frontend.yml
+++ b/.github/workflows/called-cve-frontend.yml
@@ -19,8 +19,8 @@ jobs:
     name: CVE scan frontend (npm audit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.github/workflows/called-cve-python.yml
+++ b/.github/workflows/called-cve-python.yml
@@ -19,8 +19,8 @@ jobs:
     name: CVE scan Python (pip-audit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install pip-audit

--- a/.github/workflows/called-lint-frontend.yml
+++ b/.github/workflows/called-lint-frontend.yml
@@ -21,8 +21,8 @@ jobs:
     env:
       RUN_A11Y: ${{ inputs.run-a11y }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.github/workflows/called-lint-python.yml
+++ b/.github/workflows/called-lint-python.yml
@@ -15,8 +15,8 @@ jobs:
     name: Lint Python (black + ruff)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install linters

--- a/.github/workflows/called-test-frontend.yml
+++ b/.github/workflows/called-test-frontend.yml
@@ -18,8 +18,8 @@ jobs:
     name: Test frontend (jest/vitest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node-version }}
           cache: npm

--- a/.github/workflows/called-test-python.yml
+++ b/.github/workflows/called-test-python.yml
@@ -29,8 +29,8 @@ jobs:
       JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
       JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
           cache: pip


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from `@v4` → `@v6` across 6 reusable workflows
- Bumps `actions/setup-python` from `@v5` → `@v6` in 3 Python workflows
- Bumps `actions/setup-node` from `@v4` → `@v6` in 3 frontend workflows

Resolves the Node.js 20 deprecation warnings currently appearing in downstream CI runs. GitHub forces Node.js 24 on June 2, 2026.

Closes #60
Related: wcmchenry3-stack/gaming_app#316

## Files Changed
| File | Changes |
|---|---|
| `called-lint-python.yml` | checkout v4→v6, setup-python v5→v6 |
| `called-test-python.yml` | checkout v4→v6, setup-python v5→v6 |
| `called-cve-python.yml` | checkout v4→v6, setup-python v5→v6 |
| `called-cve-frontend.yml` | checkout v4→v6, setup-node v4→v6 |
| `called-lint-frontend.yml` | checkout v4→v6, setup-node v4→v6 |
| `called-test-frontend.yml` | checkout v4→v6, setup-node v4→v6 |

## Test plan
- [ ] Verify downstream CI in `gaming_app` passes with no Node.js 20 deprecation warnings after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)