### PR TITLE
chore: add wcm_portfolio_site and buffingchi_site to community health sync matrix

### DIFF
--- a/.github/workflows/sync-community-health.yml
+++ b/.github/workflows/sync-community-health.yml
@@ -5,7 +5,9 @@ name: Sync Community Health Files
 #
 # Required secret: COMMUNITY_HEALTH_SYNC_PAT
 #   Fine-grained PAT with Contents: write + Pull requests: write on all repos
-#   listed in the matrix below. A classic PAT with `repo` scope also works.
+#   listed in the matrix below: gaming_app, office_holder_cursor, book_app,
+#   powerplayshistory_site, wcm_portfolio_site, buffingchi_site.
+#   A classic PAT with `repo` scope also works.
 
 on:
   push:
@@ -31,6 +33,8 @@ jobs:
           - office_holder_cursor
           - book_app
           - powerplayshistory_site
+          - wcm_portfolio_site
+          - buffingchi_site
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `wcm_portfolio_site` and `buffingchi_site` to the `sync-community-health.yml` matrix
- Updates the header comment to list all six target repos
- PAT already updated with access to both new repos

## Test plan
- [ ] Merge → manually trigger workflow → sync PRs open in `wcm_portfolio_site` and `buffingchi_site`

🤖 Generated with [Claude Code](https://claude.com/claude-code)