### PR TITLE
fix: reduce workflow-failure issue noise and improve ZAP coverage

### DIFF
--- a/.github/workflows/called-zap-scheduled.yml
+++ b/.github/workflows/called-zap-scheduled.yml
@@ -12,6 +12,13 @@ on:
         description: 'Name for the uploaded ZAP report artifact'
         type: string
         required: true
+      branches:
+        description: >
+          Comma-separated list of branches that should run the scan.
+          Leave empty to always run (default). Example: "main,dev"
+        type: string
+        required: false
+        default: ''
 
 jobs:
   zap-scan:
@@ -22,15 +29,28 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Guard – branch filter
+        id: guard
+        run: |
+          BRANCHES="${{ inputs.branches }}"
+          CURRENT="${{ github.ref_name }}"
+          if [ -z "$BRANCHES" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif echo "$BRANCHES" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | grep -qxF "$CURRENT"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "⏭ Skipping ZAP scan: branch '$CURRENT' not in [$BRANCHES]"
+          fi
       - name: Run ZAP baseline scan
-        if: ${{ inputs.target-url != '' }}
+        if: ${{ steps.guard.outputs.run == 'true' && inputs.target-url != '' }}
         uses: zaproxy/action-baseline@v0.15.0
         with:
           target: ${{ inputs.target-url }}
           fail_action: false
       - name: Upload ZAP report
         uses: actions/upload-artifact@v4
-        if: ${{ inputs.target-url != '' }}
+        if: ${{ steps.guard.outputs.run == 'true' && inputs.target-url != '' }}
         with:
           name: ${{ inputs.artifact-name }}-${{ github.run_id }}
           path: report_html.html

--- a/.github/workflows/scheduled-workflow-failure-monitor.yml
+++ b/.github/workflows/scheduled-workflow-failure-monitor.yml
@@ -35,7 +35,7 @@ jobs:
               --repo "$ORG/$repo" \
               --status failure \
               --created ">$SINCE" \
-              --limit 20 \
+              --limit 50 \
               --json name,conclusion,url,createdAt,headBranch \
               --jq '.[] | "- **\(.name)** on `\(.headBranch)` — [\(.createdAt)](\(.url))"' \
               2>/dev/null || true)
@@ -73,6 +73,22 @@ jobs:
           gh label create "$LABEL" --repo "$ORG/.github" \
             --description "Automated workflow failure alert" \
             --color "D93F0B" 2>/dev/null || true
+
+          # Close any stale open workflow-failure issues from previous days
+          STALE=$(gh issue list \
+            --repo "$ORG/.github" \
+            --label "$LABEL" \
+            --state open \
+            --json number \
+            --jq '.[].number' \
+            2>/dev/null || true)
+          for num in $STALE; do
+            gh issue close "$num" \
+              --repo "$ORG/.github" \
+              --comment "Superseded by the $TODAY failure report." \
+              2>/dev/null || true
+            echo "Closed stale issue #$num."
+          done
 
           gh issue create \
             --repo "$ORG/.github" \


### PR DESCRIPTION
## Summary

- **Auto-close stale failure issues** — the monitor now closes all open `workflow-failure` issues before creating a new daily one, so only one is ever open at a time (fixes the issues 59/62/63 pile-up)
- **Raise per-repo run limit 20 → 50** — busy repos like `gaming_app` were hitting the cap and getting truncated reports
- **ZAP branch filter input** — `called-zap-scheduled.yml` gains an optional `branches` input (e.g. `"main,dev"`); when set, the scan is skipped on branches not in the list, letting callers suppress noise from feature-branch runs where no service is deployed

## Test plan

- [ ] Verify the monitor closes issues 59/62/63 (already done manually) and creates a fresh one on next run
- [ ] Confirm no existing callers are broken — `branches` defaults to `''` (run always), so it's fully backward-compatible
- [ ] After merging, update individual repo `zap-scan.yml` callers to pass `branches: "main,dev"` to suppress feature-branch ZAP noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)