### PR TITLE
fix: policy-gate hook false positives on branches targeting dev

### DIFF
--- a/.claude/hooks/policy-gate.sh
+++ b/.claude/hooks/policy-gate.sh
@@ -21,10 +21,17 @@ if [ ! -f "$PATTERNS_FILE" ]; then
 fi
 
 # ── Get changed files ────────────────────────────────────────────
-# Try PR context first (origin/main...HEAD), fall back to HEAD~1
-CHANGED_FILES=$(git diff --name-only origin/main...HEAD 2>/dev/null || \
-                git diff --name-only HEAD~1 HEAD 2>/dev/null || \
-                echo "")
+# Use merge-base against the PR target branch (dev, then main) so we
+# only see files actually changed on this branch, not everything that
+# dev has over main.
+MERGE_BASE=$(git merge-base origin/dev HEAD 2>/dev/null || \
+             git merge-base origin/main HEAD 2>/dev/null || \
+             echo "")
+if [ -n "$MERGE_BASE" ]; then
+  CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD 2>/dev/null || echo "")
+else
+  CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+fi
 
 if [ -z "$CHANGED_FILES" ]; then
   exit 0
@@ -33,7 +40,7 @@ fi
 # ── Check each policy's detection patterns ───────────────────────
 TRIGGERED=""
 
-for POLICY in $(jq -r 'keys[]' "$PATTERNS_FILE"); do
+for POLICY in $(jq -r 'to_entries[] | select(.value | type == "object") | .key' "$PATTERNS_FILE"); do
   DETECT=$(jq -r --arg p "$POLICY" '.[$p].detect' "$PATTERNS_FILE")
   SKIP=$(jq -r --arg p "$POLICY" '.[$p].skip // empty' "$PATTERNS_FILE")
 


### PR DESCRIPTION
Closes #38

## Root causes

**1 — Wrong diff base**
The hook was diffing `origin/main...HEAD` (three-dot), which includes every file that `dev` has accumulated over `main` — not just what the current branch changed. A one-line HTML edit on a branch off `dev` would show dozens of unrelated files from prior merged PRs.

**Fix:** Use `git merge-base origin/dev HEAD` to find the exact point where the branch diverged, then diff from there. Falls back to `origin/main` if `dev` doesn't exist.

**2 — Non-object keys in `policy-patterns.json` breaking `jq`**
`jq 'keys[]'` iterates every top-level key, including comment/meta keys like `_note`. When `.detect` is read from a string value, `jq` returns the literal string `"null"`, which `grep -qE "null"` then matches against any file containing that string — false positives everywhere.

**Fix:** Filter with `to_entries[] | select(.value | type == "object")` so only real policy entries are iterated.

## Test plan
- [ ] Create a branch off `dev` with a 1-line HTML change and confirm `gh pr create` passes without policy triggers
- [ ] Create a branch that actually touches an OpenAI import and confirm it still triggers correctly
- [ ] Add a `_note` key to `policy-patterns.json` locally and confirm the hook ignores it

🤖 Generated with [Claude Code](https://claude.com/claude-code)