### PR TITLE
feat: shift lint left with PostToolUse lint-on-edit hook

### DIFF
--- a/.claude/hooks/lint-on-edit.sh
+++ b/.claude/hooks/lint-on-edit.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# lint-on-edit.sh — PostToolUse hook for Claude Code
+# Immediately lints the file that was just written or edited.
+# Surfaces issues to Claude before they accumulate and block PR creation.
+#
+# Triggered by: PostToolUse on Write, Edit
+# Exit 0 = clean / linter not present (no noise)
+# Exit 1 = lint errors found (Claude sees stderr and fixes them)
+
+set -uo pipefail
+
+INPUT=$(cat)
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+
+# Nothing to lint
+[ -z "$FILE" ] || [ ! -f "$FILE" ] && exit 0
+
+EXT="${FILE##*.}"
+REPORT=""
+FAIL=0
+
+# ── JavaScript / TypeScript ───────────────────────────────────────────────
+case "$EXT" in
+  js|jsx|ts|tsx|mjs|cjs)
+    if [ -x "node_modules/.bin/eslint" ]; then
+      OUT=$(npx eslint "$FILE" 2>&1) || {
+        FAIL=1
+        REPORT+="ESLint errors in $FILE:\n$OUT\n\n"
+      }
+    fi
+    if [ -x "node_modules/.bin/prettier" ]; then
+      OUT=$(npx prettier --check "$FILE" 2>&1) || {
+        FAIL=1
+        REPORT+="Prettier formatting in $FILE:\n$OUT\n\n"
+      }
+    fi
+    ;;
+
+# ── Python ────────────────────────────────────────────────────────────────
+  py)
+    if command -v ruff &>/dev/null; then
+      OUT=$(ruff check --no-fix "$FILE" 2>&1) || {
+        FAIL=1
+        REPORT+="ruff errors in $FILE:\n$OUT\n\n"
+      }
+    fi
+    if command -v black &>/dev/null; then
+      OUT=$(black --check --quiet "$FILE" 2>&1) || {
+        FAIL=1
+        REPORT+="black formatting in $FILE:\n$OUT\n\n"
+      }
+    fi
+    ;;
+
+# ── Shell scripts ─────────────────────────────────────────────────────────
+  sh|bash)
+    if command -v shellcheck &>/dev/null; then
+      OUT=$(shellcheck "$FILE" 2>&1) || {
+        FAIL=1
+        REPORT+="shellcheck issues in $FILE:\n$OUT\n\n"
+      }
+    fi
+    ;;
+
+# ── YAML ──────────────────────────────────────────────────────────────────
+  yml|yaml)
+    # Always validate syntax — Python stdlib, no deps
+    OUT=$(python3 -c "
+import yaml, sys
+try:
+    yaml.safe_load(open(sys.argv[1]))
+except yaml.YAMLError as e:
+    print(e, file=sys.stderr)
+    sys.exit(1)
+" "$FILE" 2>&1) || {
+      FAIL=1
+      REPORT+="YAML syntax error in $FILE:\n$OUT\n\n"
+    }
+    ;;
+
+# ── JSON ──────────────────────────────────────────────────────────────────
+  json)
+    OUT=$(python3 -c "
+import json, sys
+try:
+    json.load(open(sys.argv[1]))
+except json.JSONDecodeError as e:
+    print(e, file=sys.stderr)
+    sys.exit(1)
+" "$FILE" 2>&1) || {
+      FAIL=1
+      REPORT+="JSON syntax error in $FILE:\n$OUT\n\n"
+    }
+    ;;
+esac
+
+# ── Verdict ───────────────────────────────────────────────────────────────
+if [ "$FAIL" -ne 0 ]; then
+  printf 'Lint issue(s) found — fix before moving on:\n\n%b' "$REPORT" >&2
+  exit 1
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/lint-on-edit.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Problem

Lint failures follow a consistent cycle in the issue reports: Claude edits many files across a session, errors accumulate silently, then \`lint-gate.sh\` blocks \`gh pr create\` and a full lint-review agent pass is required. The gate works, but it fires too late.

## Solution

Add a \`PostToolUse\` hook on \`Write\` and \`Edit\` that immediately lints the file just modified. Claude sees the error in the same turn and fixes it before moving on. The existing \`lint-gate.sh\` is unchanged — it stays as the hard stop. This is the early warning.

## Hook coverage

| File type | Tool |
|---|---|
| \`.js\` \`.jsx\` \`.ts\` \`.tsx\` | ESLint + Prettier (if in \`node_modules\`) |
| \`.py\` | ruff + black (if installed) |
| \`.sh\` \`.bash\` | shellcheck (if installed) |
| \`.yml\` \`.yaml\` | \`yaml.safe_load\` — always available, catches workflow syntax errors |
| \`.json\` | \`json.load\` — always available |

All linters are skipped gracefully if not installed — no noise in repos that don't use them.

## Trend context

Reviewing issues 59/62/63: beyond lint, the other recurring patterns are ZAP scan noise (fixed in #65), deploy failures (render preflight in #67), and \`book_app\` expo-sdk-upgrade-tracker (needs repo-level fix). The YAML syntax validation in this hook also addresses workflow file errors that were causing CI failures.

## Test plan
- [ ] Edit a TS file with a lint error — confirm Claude sees ESLint output immediately and fixes it
- [ ] Edit a workflow YAML with a syntax error — confirm \`yaml.safe_load\` fires and reports it
- [ ] Edit a clean file — confirm hook exits silently (no noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)