### PR TITLE
feat: expand sync FILE_MAP and add org profile README

### DIFF
--- a/.github/workflows/sync-community-health.yml
+++ b/.github/workflows/sync-community-health.yml
@@ -65,8 +65,16 @@ jobs:
                   '.github/ISSUE_TEMPLATE/feature_request.md',
               '.claude/hooks/lint-on-edit.sh':
                   '.claude/hooks/lint-on-edit.sh',
+              '.claude/hooks/lint-gate.sh':
+                  '.claude/hooks/lint-gate.sh',
+              '.claude/hooks/policy-gate.sh':
+                  '.claude/hooks/policy-gate.sh',
               '.claude/agents/plan-issues.md':
                   '.claude/agents/plan-issues.md',
+              '.claude/agents/lint-review.md':
+                  '.claude/agents/lint-review.md',
+              '.claude/agents/policy-compliance.md':
+                  '.claude/agents/policy-compliance.md',
               'community-health/workflows/commitlint.yml':
                   '.github/workflows/commitlint.yml',
               'community-health/workflows/release-please.yml':
@@ -115,16 +123,18 @@ jobs:
                   else:
                       print(f'  {dest}: up-to-date')
 
-          # -- Merge PostToolUse block into .claude/settings.json ---------------
-          # We never overwrite the whole file — only inject/update the
-          # PostToolUse key so repo-specific hooks are preserved.
+          # -- Merge PreToolUse and PostToolUse blocks into .claude/settings.json --
+          # We never overwrite the whole file — only inject/update the hook keys
+          # so repo-specific hooks are preserved.
           import json as _json
 
-          canonical_raw = open('.claude/settings.json').read()
-          canonical     = _json.loads(canonical_raw)
-          canonical_post = canonical.get('hooks', {}).get('PostToolUse', [])
+          canonical_raw   = open('.claude/settings.json').read()
+          canonical       = _json.loads(canonical_raw)
+          canonical_hooks = canonical.get('hooks', {})
+          canonical_pre   = canonical_hooks.get('PreToolUse', [])
+          canonical_post  = canonical_hooks.get('PostToolUse', [])
 
-          if canonical_post:
+          if canonical_pre or canonical_post:
               dest_settings = '.claude/settings.json'
               existing_raw  = api(
                   f'/repos/{REPO}/contents/{dest_settings}?ref={default_branch}'
@@ -139,15 +149,24 @@ jobs:
                   existing = {'hooks': {}}
 
               existing.setdefault('hooks', {})
+              current_pre  = existing['hooks'].get('PreToolUse', [])
               current_post = existing['hooks'].get('PostToolUse', [])
 
-              if current_post != canonical_post or FORCE:
+              changed = False
+              if canonical_pre and (current_pre != canonical_pre or FORCE):
+                  existing['hooks']['PreToolUse'] = canonical_pre
+                  print(f'  {dest_settings}: PreToolUse differs → will merge')
+                  changed = True
+              if canonical_post and (current_post != canonical_post or FORCE):
                   existing['hooks']['PostToolUse'] = canonical_post
-                  merged_content = _json.dumps(existing, indent=2) + '\n'
                   print(f'  {dest_settings}: PostToolUse differs → will merge')
+                  changed = True
+
+              if changed:
+                  merged_content = _json.dumps(existing, indent=2) + '\n'
                   needs_update.append(('__settings_merge__', dest_settings, merged_content))
               else:
-                  print(f'  {dest_settings}: PostToolUse already up-to-date')
+                  print(f'  {dest_settings}: hooks already up-to-date')
 
           if not needs_update:
               print('  Nothing to sync.')
@@ -202,11 +221,15 @@ jobs:
               '- `.github/PULL_REQUEST_TEMPLATE.md`\n'
               '- `.github/ISSUE_TEMPLATE/bug_report.md`\n'
               '- `.github/ISSUE_TEMPLATE/feature_request.md`\n'
-              '- `.claude/hooks/lint-on-edit.sh` _(new: immediate lint feedback on file edits)_\n'
-              '- `.claude/agents/plan-issues.md` _(new: structured GitHub issue planning agent)_\n'
-              '- `.claude/settings.json` _(merged: PostToolUse hook wired up)_\n'
-              '- `.github/workflows/commitlint.yml` _(new: enforces Conventional Commits on PR titles)_\n'
-              '- `.github/workflows/release-please.yml` _(new: automated release PRs, CHANGELOG, and git tags)_\n\n'
+              '- `.claude/hooks/lint-on-edit.sh` _(immediate lint feedback on file edits)_\n'
+              '- `.claude/hooks/lint-gate.sh` _(blocks `gh pr create` if lint fails)_\n'
+              '- `.claude/hooks/policy-gate.sh` _(blocks `gh pr create` if API policy files detected)_\n'
+              '- `.claude/agents/plan-issues.md` _(structured GitHub issue planning agent)_\n'
+              '- `.claude/agents/lint-review.md` _(auto-fixes lint issues when lint-gate blocks)_\n'
+              '- `.claude/agents/policy-compliance.md` _(reviews and fixes policy violations when policy-gate blocks)_\n'
+              '- `.claude/settings.json` _(merged: PreToolUse and PostToolUse hooks wired up)_\n'
+              '- `.github/workflows/commitlint.yml` _(enforces Conventional Commits on PR titles)_\n'
+              '- `.github/workflows/release-please.yml` _(automated release PRs, CHANGELOG, and git tags)_\n\n'
               '_Auto-generated by `sync-community-health.yml`. '
               'Review and merge to apply the update._'
           )


### PR DESCRIPTION
## Summary

**Issue #84 — Expand sync FILE_MAP to full Claude Code tooling**
- Adds `lint-gate.sh`, `policy-gate.sh`, `lint-review.md`, and `policy-compliance.md` to the `FILE_MAP` in `sync-community-health.yml`
- Extends the `.claude/settings.json` merge to cover **PreToolUse** hooks (the PR gate hooks) in addition to the existing PostToolUse merge
- Updates the PR body template to list all newly synced files

**Issue #86 — Org profile README**
- Adds `profile/README.md` so the org homepage at github.com/wcmchenry3-stack displays a project index and standards summary
- GitHub reads this from the public `.github` repo; trade-off noted in issue #89 (when the repo goes private, this page disappears — no GitHub-native workaround exists for org profiles from a private `.github` repo)

## Why

Target repos were receiving only 40% of the org's Claude Code tooling. Without the PR gate hooks and auto-fix agents, Claude Code in app repos has no PR governance. This closes the gap.

The org also had no profile page — `profile/README.md` is the GitHub-supported mechanism for org homepages.

## Test plan

- [ ] Merge to `main` and verify `sync-community-health.yml` opens sync PRs in all 6 target repos
- [ ] Confirm the sync PRs include the 4 new hook/agent files and updated `.claude/settings.json` with `PreToolUse` wired up
- [ ] In a target repo after sync merge, run `gh pr create` — verify lint gate and policy gate fire
- [ ] Visit github.com/wcmchenry3-stack — confirm org profile README is visible

Closes #84, closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)