### PR TITLE
feat: enforce design tokens and WCAG 2.2 AA via PR policy checks

### DIFF
--- a/.claude/hooks/policy-gate.sh
+++ b/.claude/hooks/policy-gate.sh
@@ -48,8 +48,9 @@ for POLICY in $(jq -r 'to_entries[] | select(.value | type == "object") | .key' 
     # Skip .claude/ directory (contains policy definitions with pattern strings)
     case "$file" in .claude/*) continue ;; esac
 
-    # Skip files matching the skip pattern
-    if [ -n "$SKIP" ] && echo "$(basename "$file")" | grep -qE "$SKIP"; then
+    # Skip files matching the skip pattern (checked against full path and basename
+    # so patterns can exclude by directory prefix OR by filename)
+    if [ -n "$SKIP" ] && { echo "$file" | grep -qE "$SKIP" || echo "$(basename "$file")" | grep -qE "$SKIP"; }; then
       continue
     fi
 

--- a/.claude/policies/design-tokens.md
+++ b/.claude/policies/design-tokens.md
@@ -1,0 +1,96 @@
+# Design Tokens & Accessibility Policy
+
+Policy references:
+- https://www.w3.org/TR/WCAG22/ (WCAG 2.2)
+- https://www.w3.org/WAI/ARIA/apg/ (ARIA Authoring Practices)
+- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA
+
+## Detection
+
+Files matching ANY of these patterns trigger this policy:
+
+- `:\s*#[0-9a-fA-F]{3,8}|rgba?\s*\(|hsla?\s*\(|font-size:\s*[0-9]+px|font-family:\s*["']|tabindex=["'][1-9]`
+
+Skip the following (checked against full path and basename):
+- `node_modules/`, `dist/`, `build/`, `.cache/`, `coverage/`, `public/`
+- Token definition files: `tokens/`, `*.tokens.json`, `tailwind.config.*`, `theme.*.ts/js`
+- Minified files: `*.min.css`, `*.min.js`
+- Storybook: `*.stories.tsx`, `*.stories.ts`
+- Tests: `*.test.*`, `*.spec.*`, `__snapshots__/`
+- Non-UI assets: `*.svg`, `*.md`, `*.mdx`
+
+## Checks
+
+### Check 1: Hex color hardcoded [error]
+
+**Pattern**: `:\s*#[0-9a-fA-F]{3,8}[;\s"'\}]`
+**Presence**: forbidden
+**Message**: Hardcoded hex color detected. Replace with a design token (e.g. `var(--color-brand-primary)` in CSS, or the equivalent token constant in JS/TS). Hard-coded colors diverge from brand guidelines and make theme changes impossible.
+**Reference**: https://www.w3.org/TR/WCAG22/#use-of-color
+
+### Check 2: RGB/HSL color literal [error]
+
+**Pattern**: `(color|background|background-color|border-color|fill|stroke|outline-color):\s*(rgb|rgba|hsl|hsla)\s*\(`
+**Presence**: forbidden
+**Message**: Hardcoded RGB/HSL color detected. Use a design token instead. RGB/HSL literals bypass the branding system just as hex codes do.
+**Reference**: https://www.w3.org/TR/WCAG22/#use-of-color
+
+### Check 3: Hardcoded font-size in px [error]
+
+**Pattern**: `font-size:\s*[0-9]+px`
+**Presence**: forbidden
+**Message**: Hardcoded `font-size` in `px` detected. Use a design token (e.g. `var(--font-size-md)`) or a relative unit (`rem`/`em`) so user browser font-size preferences are respected. Hard-coded `px` sizes break WCAG 1.4.4 (Resize Text).
+**Reference**: https://www.w3.org/TR/WCAG22/#resize-text
+
+### Check 4: Hardcoded font-family [warning]
+
+**Pattern**: `font-family:\s*["'][^"']+["']`
+**Presence**: forbidden
+**Message**: Hardcoded `font-family` string literal detected. Reference a design token (e.g. `var(--font-family-sans)`) so the typeface can be updated centrally without touching component code.
+**Reference**: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family
+
+### Check 5: tabindex > 0 [error]
+
+**Pattern**: `tabindex=["'][1-9][0-9]*["']`
+**Presence**: forbidden
+**Message**: Positive `tabindex` value detected. Values > 0 override the natural DOM tab order and create a confusing keyboard navigation experience. Use `tabindex="0"` to make an element focusable in DOM order, or `tabindex="-1"` for programmatic-only focus. See WCAG 2.4.3 (Focus Order).
+**Reference**: https://www.w3.org/TR/WCAG22/#focus-order
+
+### Check 6: onclick/onkeydown on non-interactive elements [warning]
+
+**Pattern**: `<(div|span|p|section|article|header|footer|main|aside)\b[^>]*on(click|keydown|keyup|keypress)=`
+**Presence**: forbidden
+**Message**: Event handler on a non-interactive element detected. Use a native `<button>` or `<a>` element instead — they have built-in keyboard support, focus management, and ARIA semantics. If a custom interactive element is truly required, add `role="button"` and `tabindex="0"`. See WCAG 4.1.2 (Name, Role, Value).
+**Reference**: https://www.w3.org/TR/WCAG22/#name-role-value
+
+### Check 7: img without alt attribute [error]
+
+**Pattern**: `<img\b` on a line that does not contain `alt=`
+**Presence**: forbidden
+**Message**: `<img>` without `alt` attribute detected. All images must have `alt` text for screen-reader users (WCAG 1.1.1 Non-text Content). Use `alt=""` for purely decorative images (add `role="presentation"` too), or a descriptive string for informational images.
+**Reference**: https://www.w3.org/TR/WCAG22/#non-text-content
+
+### Check 8: aria-hidden on focusable elements [warning]
+
+**Pattern**: `aria-hidden="true"` on the same line as `href=|tabindex=|<button|<input|<select|<textarea|<a\s`
+**Presence**: forbidden
+**Message**: `aria-hidden="true"` on a potentially focusable element. Hidden elements remain keyboard-reachable, creating invisible focus traps for keyboard-only and AT users. Remove `aria-hidden` or move it to a non-focusable wrapper. See WCAG 4.1.2.
+**Note**: This is a same-line heuristic only — multi-line JSX may not be caught. Manual review required.
+**Reference**: https://www.w3.org/TR/WCAG22/#name-role-value
+
+## Auto-Fix Guidance
+
+### Safe to auto-fix
+- **Hex colors / RGB / HSL in CSS files**: Replace literal value with a CSS custom property (`var(--color-...)`) if a matching token exists in the project's token file. If no token exists, flag for human review — do not invent token names.
+- **Font-size px → rem**: Convert `font-size: Npx` to `font-size: calc(N / 16 * 1rem)` as a migration comment, then flag for the developer to map to the appropriate token.
+- **tabindex > 0 → 0 or -1**: Replace `tabindex="N"` (N > 0) with `tabindex="0"` when the element needs to be in the natural tab order. Flag if the intent is unclear.
+- **img missing alt**: Add `alt=""` as a placeholder and add a `TODO(a11y): add descriptive alt text` comment. Never invent alt text — flag for human review.
+
+### Requires human review
+- **Font-family literals**: Token mapping depends on the project's design system. Flag with the token name suggestion if the project has a `tokens/` directory.
+- **Event handlers on non-interactive elements**: Refactoring to `<button>` / `<a>` may break layout or styling. Flag the element and the required fix; do not auto-rewrite.
+- **aria-hidden on focusable elements**: Fixing this requires understanding the intent. Flag only.
+
+### Never auto-fix
+- **Brand colors**: Do not silently remap a hex value to a token — the color may be intentional and unmatched in the design system. Always flag for human review.
+- **Accessibility roles**: Do not add or remove ARIA roles automatically.

--- a/.claude/policies/policy-patterns.json
+++ b/.claude/policies/policy-patterns.json
@@ -14,5 +14,9 @@
   "claude": {
     "detect": "from anthropic|import anthropic|@anthropic-ai/sdk|Anthropic\\(|ANTHROPIC_API_KEY|claude_agent_sdk",
     "skip": "^\\.env"
+  },
+  "design-tokens": {
+    "detect": ":\\s*#[0-9a-fA-F]{3,8}|rgba?\\s*\\(|hsla?\\s*\\(|font-size:\\s*[0-9]+px|font-family:\\s*[\"']|tabindex=[\"'][1-9]",
+    "skip": "node_modules/|(^|/)dist/|(^|/)build/|(^|/)\\.cache/|(^|/)coverage/|(^|/)public/|(^|/)tokens/|\\.min\\.(css|js)|\\.stories\\.[jt]sx?|\\.test\\.[jt]sx?|\\.spec\\.[jt]sx?|__snapshots__|\\.svg$|\\.mdx?$|\\.tokens\\.json$|tailwind\\.config\\.|theme\\.[^./]+\\.[jt]sx?$"
   }
 }

--- a/.github/policy-enforcement.yml
+++ b/.github/policy-enforcement.yml
@@ -17,6 +17,7 @@
 defaults:
   openai: advisory
   gemini: advisory
+  design-tokens: advisory
 
 # Per-repo overrides. Uncomment and set to `required` when the repo
 # begins calling the API. Repo key is the bare repo name (no owner).

--- a/.github/workflows/called-design-token-check.yml
+++ b/.github/workflows/called-design-token-check.yml
@@ -1,0 +1,332 @@
+name: Design Tokens & Accessibility Check
+
+# Validates that PR code in frontend files does not contain hard-coded
+# CSS values (colors, font sizes, font families) that should use design
+# tokens, and does not introduce common WCAG 2.2 AA accessibility violations.
+#
+# Policy references:
+#   https://www.w3.org/TR/WCAG22/
+#   https://www.w3.org/WAI/ARIA/apg/
+#
+# Applied to all repos. Checks are skipped automatically when no changed
+# files contain hard-coded style values or accessibility anti-patterns.
+#
+# Skip logic mirrors .claude/policies/design-tokens.md — update both together.
+
+on:
+  workflow_call:
+    inputs:
+      policy-version:
+        required: false
+        type: string
+        default: '2026-04-11'
+        description: >
+          ISO date this workflow was last reviewed against WCAG 2.2 and the
+          org design token conventions. Bump after reviewing upstream changes.
+
+jobs:
+  design-token-check:
+    name: Design Tokens & Accessibility Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Identify changed files with hard-coded style values
+        id: find-style-files
+        run: |
+          BASE_REF="${{ github.base_ref }}"
+          if [ -n "$BASE_REF" ]; then
+            git diff --name-only "origin/${BASE_REF}...HEAD" > changed_files.txt
+          else
+            git diff --name-only HEAD~1 HEAD > changed_files.txt 2>/dev/null || touch changed_files.txt
+          fi
+
+          echo "All changed files:"
+          cat changed_files.txt
+
+          > style_files.txt
+          while IFS= read -r file; do
+            # Skip .claude/ policy/config files
+            case "$file" in .claude/*) continue ;; esac
+
+            # Skip by path (directory-level exclusions)
+            if echo "$file" | grep -qE \
+              'node_modules/|(^|/)dist/|(^|/)build/|(^|/)\.cache/|(^|/)coverage/|(^|/)public/|(^|/)tokens/'; then
+              continue
+            fi
+
+            # Skip by filename (token definitions, generated, non-UI assets)
+            case "$(basename "$file")" in
+              *.min.css|*.min.js) continue ;;
+              *.stories.tsx|*.stories.ts|*.stories.jsx|*.stories.js) continue ;;
+              *.test.ts|*.test.tsx|*.test.js|*.test.jsx) continue ;;
+              *.spec.ts|*.spec.tsx|*.spec.js|*.spec.jsx) continue ;;
+              *.svg|*.md|*.mdx) continue ;;
+              *.tokens.json) continue ;;
+              tailwind.config.*|tailwind.config.ts|tailwind.config.js) continue ;;
+            esac
+            case "$file" in
+              *__snapshots__*|*__fixtures__*) continue ;;
+              theme.*.ts|theme.*.tsx|theme.*.js) continue ;;
+            esac
+
+            # Detect files with hard-coded style values or a11y anti-patterns
+            if [ -f "$file" ] && grep -qiE \
+              ':\s*#[0-9a-fA-F]{3,8}|rgba?\s*\(|hsla?\s*\(|font-size:\s*[0-9]+px|font-family:\s*["\x27]|tabindex=["\x27][1-9]' \
+              "$file"; then
+              echo "$file" >> style_files.txt
+            fi
+          done < changed_files.txt
+
+          if [ ! -s style_files.txt ]; then
+            echo "No changed files contain hard-coded style values — checks skipped."
+            echo "has_style_files=false" >> "$GITHUB_OUTPUT"
+          else
+            echo ""
+            echo "Files with hard-coded style values or a11y patterns:"
+            cat style_files.txt
+            echo "has_style_files=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ---------------------------------------------------------------
+      # Load enforcement mode for design-token policy.
+      # When mode == "required", violations fail the check.
+      # When mode == "advisory" (default), violations are annotated only.
+      # ---------------------------------------------------------------
+      - name: Load enforcement mode
+        id: enforce
+        run: |
+          CONFIG_URL="https://raw.githubusercontent.com/wcmchenry3-stack/.github/main/.github/policy-enforcement.yml"
+          if ! curl -sfL "$CONFIG_URL" -o /tmp/policy-enforcement.yml; then
+            echo "::warning::Could not fetch policy-enforcement.yml — defaulting to advisory"
+            echo "mode=advisory" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          MODE=$(yq ".overrides.\"${REPO_NAME}\"[\"design-tokens\"] // .defaults[\"design-tokens\"] // \"advisory\"" /tmp/policy-enforcement.yml)
+          if [ -z "$MODE" ] || [ "$MODE" = "null" ]; then MODE="advisory"; fi
+          echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
+          echo "::notice::Design-token policy enforcement mode for ${REPO_NAME}: ${MODE}"
+
+      # ---------------------------------------------------------------
+      # Check 1: Hex color hardcoded [error]
+      # Hard-coded hex values bypass the design token system and make
+      # brand-wide color changes require touching every component.
+      # ---------------------------------------------------------------
+      - name: 'Check 1: Hex color hardcoded'
+        if: steps.find-style-files.outputs.has_style_files == 'true'
+        run: |
+          FAIL=0
+          HEX_PATTERN=':\s*#[0-9a-fA-F]{3,8}[;,\s"'"'"'\}]'
+          while IFS= read -r file; do
+            if grep -qE "$HEX_PATTERN" "$file"; then
+              MATCHES=$(grep -nE "$HEX_PATTERN" "$file" | head -5)
+              echo "::error file=$file::Hard-coded hex color detected. Replace with a design token (e.g. var(--color-brand-primary)). Hard-coded colors diverge from brand guidelines and make theme changes impossible. Matches: $MATCHES"
+              FAIL=1
+            fi
+          done < style_files.txt
+          if [ "$FAIL" -eq 0 ]; then
+            echo "Check 1 passed: No hard-coded hex colors detected."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 1 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
+          fi
+          exit "$FAIL"
+
+      # ---------------------------------------------------------------
+      # Check 2: RGB/HSL color literal [error]
+      # rgba()/hsla() literal values are just as brittle as hex codes —
+      # both bypass the token system.
+      # ---------------------------------------------------------------
+      - name: 'Check 2: RGB/HSL color literal'
+        if: steps.find-style-files.outputs.has_style_files == 'true'
+        run: |
+          FAIL=0
+          RGBHSL_PATTERN='(color|background|background-color|border-color|fill|stroke|outline-color):\s*(rgb|rgba|hsl|hsla)\s*\('
+          while IFS= read -r file; do
+            if grep -qiE "$RGBHSL_PATTERN" "$file"; then
+              MATCHES=$(grep -niE "$RGBHSL_PATTERN" "$file" | head -5)
+              echo "::error file=$file::Hard-coded RGB/HSL color detected. Use a design token instead of inline color functions. Matches: $MATCHES"
+              FAIL=1
+            fi
+          done < style_files.txt
+          if [ "$FAIL" -eq 0 ]; then
+            echo "Check 2 passed: No hard-coded RGB/HSL color literals detected."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 2 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
+          fi
+          exit "$FAIL"
+
+      # ---------------------------------------------------------------
+      # Check 3: Hardcoded font-size in px [error]
+      # Hard-coded px font sizes break WCAG 1.4.4 (Resize Text) because
+      # they ignore the user's browser font-size preference.
+      # https://www.w3.org/TR/WCAG22/#resize-text
+      # ---------------------------------------------------------------
+      - name: 'Check 3: Hardcoded font-size in px'
+        if: steps.find-style-files.outputs.has_style_files == 'true'
+        run: |
+          FAIL=0
+          FONTSIZE_PATTERN='font-size:\s*[0-9]+px'
+          while IFS= read -r file; do
+            if grep -qiE "$FONTSIZE_PATTERN" "$file"; then
+              MATCHES=$(grep -niE "$FONTSIZE_PATTERN" "$file" | head -5)
+              echo "::error file=$file::Hard-coded font-size in px detected. Use a design token (e.g. var(--font-size-md)) or a relative unit (rem/em) so user browser font-size preferences are respected (WCAG 1.4.4 Resize Text). Matches: $MATCHES"
+              FAIL=1
+            fi
+          done < style_files.txt
+          if [ "$FAIL" -eq 0 ]; then
+            echo "Check 3 passed: No hard-coded px font sizes detected."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 3 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
+          fi
+          exit "$FAIL"
+
+      # ---------------------------------------------------------------
+      # Check 4: Hardcoded font-family [warning]
+      # String literal font families make typeface updates require
+      # touching every component rather than one token.
+      # ---------------------------------------------------------------
+      - name: 'Check 4: Hardcoded font-family (warning)'
+        if: steps.find-style-files.outputs.has_style_files == 'true'
+        run: |
+          FONTFAMILY_PATTERN="font-family:\s*[\"'][^\"']+[\"']"
+          while IFS= read -r file; do
+            if grep -qiE "$FONTFAMILY_PATTERN" "$file"; then
+              MATCHES=$(grep -niE "$FONTFAMILY_PATTERN" "$file" | head -5)
+              echo "::warning file=$file::Hard-coded font-family string literal detected. Reference a design token (e.g. var(--font-family-sans)) so the typeface can be updated centrally. Matches: $MATCHES"
+            fi
+          done < style_files.txt
+          echo "Check 4 complete: font-family warnings are informational — review before release."
+
+      # ---------------------------------------------------------------
+      # Check 5: tabindex > 0 [error]
+      # Positive tabindex values override the natural DOM tab order and
+      # create a confusing keyboard navigation experience (WCAG 2.4.3).
+      # https://www.w3.org/TR/WCAG22/#focus-order
+      # ---------------------------------------------------------------
+      - name: 'Check 5: tabindex > 0'
+        if: steps.find-style-files.outputs.has_style_files == 'true'
+        run: |
+          FAIL=0
+          TABINDEX_PATTERN='tabindex=["\x27][1-9][0-9]*["\x27]'
+          while IFS= read -r file; do
+            if grep -qE "$TABINDEX_PATTERN" "$file"; then
+              MATCHES=$(grep -nE "$TABINDEX_PATTERN" "$file" | head -5)
+              echo "::error file=$file::Positive tabindex value detected. Values > 0 override the natural DOM tab order (WCAG 2.4.3 Focus Order). Use tabindex=\"0\" to include in DOM order or tabindex=\"-1\" for programmatic focus only. Matches: $MATCHES"
+              FAIL=1
+            fi
+          done < style_files.txt
+          if [ "$FAIL" -eq 0 ]; then
+            echo "Check 5 passed: No positive tabindex values detected."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 5 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
+          fi
+          exit "$FAIL"
+
+      # ---------------------------------------------------------------
+      # Check 6: Event handler on non-interactive element [warning]
+      # onclick/onkeydown on div/span/p lack built-in keyboard support,
+      # focus management, and ARIA semantics (WCAG 4.1.2).
+      # https://www.w3.org/TR/WCAG22/#name-role-value
+      # ---------------------------------------------------------------
+      - name: 'Check 6: Event handler on non-interactive element (warning)'
+        if: steps.find-style-files.outputs.has_style_files == 'true'
+        run: |
+          HANDLER_PATTERN='<(div|span|p|section|article|header|footer|main|aside)\b[^>]*on(click|keydown|keyup|keypress)='
+          while IFS= read -r file; do
+            if grep -qiE "$HANDLER_PATTERN" "$file"; then
+              MATCHES=$(grep -niE "$HANDLER_PATTERN" "$file" | head -5)
+              echo "::warning file=$file::Event handler on a non-interactive element detected. Use a native <button> or <a> instead — they have built-in keyboard support and ARIA semantics (WCAG 4.1.2). If a custom element is required, add role=\"button\" and tabindex=\"0\". Matches: $MATCHES"
+            fi
+          done < style_files.txt
+          echo "Check 6 complete: interactive-element warnings are informational."
+
+      # ---------------------------------------------------------------
+      # Check 7: img without alt attribute [error]
+      # All images require alt text for screen-reader users (WCAG 1.1.1).
+      # Same-line heuristic — multi-line JSX img tags may need manual review.
+      # https://www.w3.org/TR/WCAG22/#non-text-content
+      # ---------------------------------------------------------------
+      - name: 'Check 7: img without alt attribute'
+        if: steps.find-style-files.outputs.has_style_files == 'true'
+        run: |
+          FAIL=0
+          while IFS= read -r file; do
+            # Find lines with <img that do not contain alt= on the same line
+            if grep -iE '<img\b' "$file" | grep -qviE 'alt='; then
+              MATCHES=$(grep -niE '<img\b' "$file" | grep -viE 'alt=' | head -5)
+              echo "::error file=$file::<img> without alt attribute detected (same-line check). All images require alt text for screen readers (WCAG 1.1.1 Non-text Content). Use alt=\"\" for decorative images (add role=\"presentation\" too) or a descriptive string for informational images. Matches: $MATCHES"
+              FAIL=1
+            fi
+          done < style_files.txt
+          if [ "$FAIL" -eq 0 ]; then
+            echo "Check 7 passed: All img elements appear to have alt attributes (same-line check)."
+          elif [ "${{ steps.enforce.outputs.mode }}" != "required" ]; then
+            echo "::warning::Check 7 found violations but enforcement mode is '${{ steps.enforce.outputs.mode }}' — not failing check."
+            exit 0
+          fi
+          exit "$FAIL"
+
+      # ---------------------------------------------------------------
+      # Check 8: aria-hidden on focusable element [warning]
+      # Hidden elements remain keyboard-reachable, creating invisible
+      # focus traps for keyboard-only and AT users (WCAG 4.1.2).
+      # Same-line heuristic — multi-line JSX requires manual review.
+      # ---------------------------------------------------------------
+      - name: 'Check 8: aria-hidden on focusable element (warning)'
+        if: steps.find-style-files.outputs.has_style_files == 'true'
+        run: |
+          ARIA_HIDDEN_PATTERN='aria-hidden=["\x27]true["\x27]'
+          FOCUSABLE_PATTERN='href=|tabindex=|<button|<input|<select|<textarea|<a\s'
+          while IFS= read -r file; do
+            if grep -qE "$ARIA_HIDDEN_PATTERN" "$file"; then
+              # Check if any aria-hidden="true" line also contains a focusable indicator
+              if grep -E "$ARIA_HIDDEN_PATTERN" "$file" | grep -qiE "$FOCUSABLE_PATTERN"; then
+                MATCHES=$(grep -nE "$ARIA_HIDDEN_PATTERN" "$file" | grep -iE "$FOCUSABLE_PATTERN" | head -5)
+                echo "::warning file=$file::aria-hidden=\"true\" appears on a potentially focusable element (same-line heuristic). Hidden elements remain keyboard-reachable, creating invisible focus traps. Remove aria-hidden or move it to a non-focusable wrapper (WCAG 4.1.2). Multi-line JSX requires manual review. Matches: $MATCHES"
+              fi
+            fi
+          done < style_files.txt
+          echo "Check 8 complete: aria-hidden warnings are informational — manual review required for multi-line JSX."
+
+      # ---------------------------------------------------------------
+      # Summary — always runs so policy metadata is visible in every log
+      # ---------------------------------------------------------------
+      - name: Policy summary
+        if: always()
+        run: |
+          echo "============================================================"
+          echo "  Design Tokens & Accessibility Policy Compliance Summary"
+          echo "============================================================"
+          echo "  Policy snapshot date : ${{ inputs.policy-version }}"
+          echo "  Repo                 : ${{ github.repository }}"
+          echo "  Enforcement mode     : ${{ steps.enforce.outputs.mode }}"
+          echo ""
+          echo "  Checks (error = blocks when required; warning = always informational):"
+          echo "    1. Hex color hardcoded              [error]"
+          echo "    2. RGB/HSL color literal            [error]"
+          echo "    3. Hardcoded font-size in px        [error]"
+          echo "    4. Hardcoded font-family            [warning]"
+          echo "    5. tabindex > 0                     [error]"
+          echo "    6. Event handler on non-interactive [warning]"
+          echo "    7. img without alt attribute        [error]"
+          echo "    8. aria-hidden on focusable element [warning]"
+          echo ""
+          echo "  Policy references:"
+          echo "    WCAG 2.2          : https://www.w3.org/TR/WCAG22/"
+          echo "    ARIA APG          : https://www.w3.org/WAI/ARIA/apg/"
+          echo "    Design token docs : see .claude/policies/design-tokens.md"
+          echo ""
+          echo "  To update after a design system or WCAG change:"
+          echo "    1. Update patterns in called-design-token-check.yml"
+          echo "    2. Update .claude/policies/design-tokens.md to match"
+          echo "    3. Bump policy-version default to today's date"
+          echo "    4. Open a PR to wcmchenry3-stack/.github"
+          echo "============================================================"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,13 +45,35 @@ A `PreToolUse` hook gates every `gh pr create` call behind a policy check.
 2. Add the detection pattern to `.claude/policies/policy-patterns.json`.
 3. No hook or agent changes needed.
 
-**Current policies:** OpenAI, Wikipedia/Wikimedia, Google Gemini.
+**Current policies:** OpenAI, Wikipedia/Wikimedia, Google Gemini, Design Tokens & Accessibility.
+
+## Design Tokens & Accessibility policy (`called-design-token-check.yml`)
+
+`called-design-token-check.yml` validates that frontend code does not contain:
+- Hard-coded CSS color values (hex, `rgb()`, `rgba()`, `hsl()`, `hsla()`) — use design tokens
+- Hard-coded `font-size` in `px` — use tokens or relative units (`rem`/`em`)
+- Hard-coded `font-family` string literals — use tokens
+- `tabindex` > 0 — breaks natural DOM tab order (WCAG 2.4.3)
+- Event handlers (`onclick`, `onkeydown`, etc.) on non-interactive elements (WCAG 4.1.2)
+- `<img>` without `alt` attribute (WCAG 1.1.1)
+- `aria-hidden="true"` on focusable elements (WCAG 4.1.2)
+
+**Skip patterns** (files excluded from checking):
+`node_modules/`, `dist/`, `build/`, `.cache/`, `coverage/`, `public/`, `tokens/`,
+`*.min.css`, `*.min.js`, `*.stories.*`, `*.test.*`, `*.spec.*`, `__snapshots__/`,
+`*.svg`, `*.md`, `*.mdx`, `*.tokens.json`, `tailwind.config.*`, `theme.*.ts/js`
+
+**Enforcement:** defaults to `advisory` in `.github/policy-enforcement.yml`.
+Flip a repo to `required` under `overrides:` once its frontend is using a design system.
+
+**Policy definition:** `.claude/policies/design-tokens.md` — update alongside the workflow.
 
 ## Org-level policy enforcement (`policy-enforcement.yml`)
 
-`called-openai-policy.yml` and `called-gemini-policy.yml` read
-`.github/policy-enforcement.yml` from this meta-repo at job start to
-decide whether violations **fail the check** or are **advisory only**.
+`called-openai-policy.yml`, `called-gemini-policy.yml`, and
+`called-design-token-check.yml` read `.github/policy-enforcement.yml` from this
+meta-repo at job start to decide whether violations **fail the check** or are
+**advisory only**.
 
 **The model:**
 - Individual repos *inherit* the policy scaffolding (agents, hooks, `.claude/policies/`).


### PR DESCRIPTION
## Summary

- Adds a `design-tokens` policy to the existing policy-gate/policy-compliance framework — no new hooks or agents needed
- New `called-design-token-check.yml` reusable workflow checks 8 rules across CSS/SCSS/JSX/TSX/HTML files
- Defaults to `advisory` enforcement; flip a repo to `required` in `policy-enforcement.yml` when it adopts a design system
- Fixes a latent bug in `policy-gate.sh` where the skip pattern was only matched against `basename`, making directory-level exclusions (`node_modules/`, `dist/`, etc.) ineffective

## Checks introduced

| # | Rule | Severity | WCAG ref |
|---|---|---|---|
| 1 | Hex color hardcoded | error | — |
| 2 | RGB/HSL color literal | error | — |
| 3 | `font-size` in `px` | error | 1.4.4 Resize Text |
| 4 | `font-family` string literal | warning | — |
| 5 | `tabindex` > 0 | error | 2.4.3 Focus Order |
| 6 | Event handler on non-interactive element | warning | 4.1.2 Name, Role, Value |
| 7 | `<img>` without `alt` | error | 1.1.1 Non-text Content |
| 8 | `aria-hidden` on focusable element | warning | 4.1.2 Name, Role, Value |

## Files changed

- `.claude/hooks/policy-gate.sh` — fix skip logic to check full path + basename
- `.claude/policies/policy-patterns.json` — add `design-tokens` detect/skip patterns
- `.claude/policies/design-tokens.md` — policy definition with checks and auto-fix guidance
- `.github/workflows/called-design-token-check.yml` — new reusable workflow
- `.github/policy-enforcement.yml` — register `design-tokens: advisory`
- `CLAUDE.md` — document the new policy and update enforcement section

## Closes

Closes #92, #93, #94, #95, #96 — all children of epic #91.

## Test plan

- [ ] Confirm `policy-gate.sh` blocks a branch that adds a `.css` file with a hex color
- [ ] Confirm skip patterns exclude `node_modules/`, `*.stories.tsx`, `*.test.tsx`, `*.svg`
- [ ] Confirm `called-design-token-check.yml` can be added to a target repo's caller workflow and produces advisory annotations on a PR with hard-coded colors
- [ ] Confirm enforcement flips to blocking when a repo is set to `required` in `policy-enforcement.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)