### PR TITLE
fix: exclude synced meta-repo files from Prettier check

### DIFF
--- a/.github/workflows/called-lint-frontend.yml
+++ b/.github/workflows/called-lint-frontend.yml
@@ -34,5 +34,10 @@ jobs:
         run: npx eslint .
         working-directory: ${{ inputs.working-directory }}
       - name: Prettier
-        run: npx prettier --check .
+        run: |
+          # Exclude synced meta-repo files that are not project code.
+          # Appends to .prettierignore (creates it if absent, safe if it exists).
+          printf '\n# Synced from wcmchenry3-stack/.github — not project code\n.claude/\nCODE_OF_CONDUCT.md\nCONTRIBUTING.md\nSUPPORT.md\nSECURITY.md\n' \
+            >> .prettierignore
+          npx prettier --check .
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Summary

- Prettier's `--check .` in `called-lint-frontend.yml` was checking `.claude/` agent/policy docs and community health files (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `SECURITY.md`) against each repo's formatting rules — these are synced from the meta-repo and are not project code
- This was causing CI failures on `chore/sync-community-health` PRs in `powerplayshistory_site`, `book_app`, and `office_holder_cursor` (visible in issue #105)

**Fix:** append the exclusions to `.prettierignore` before Prettier runs. Uses `>>` so it's safe whether the file already exists or not.

## Repos currently affected

Open `chore/sync-community-health` PRs with failing CI:
- `wcmchenry3-stack/powerplayshistory_site` #28
- `wcmchenry3-stack/wcm_portfolio_site` #81
- `wcmchenry3-stack/buffingchi_site` #16

Once this fix merges to `main`, re-trigger CI on those sync PRs and they should go green.

## Test plan

- [ ] Merge this PR
- [ ] Re-run CI on `powerplayshistory_site` sync PR #28 — Prettier step should pass
- [ ] Confirm the `.prettierignore` append does not clobber existing ignore rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)