### PR TITLE
feat: add schema migration CI workflow and document CI hardening lessons

### DIFF
--- a/.github/workflows/called-schema-migration.yml
+++ b/.github/workflows/called-schema-migration.yml
@@ -1,0 +1,152 @@
+name: Schema Migration Check
+
+# Validates schema and migration file changes on PRs.
+# Only runs when schema/migration/model files are actually touched — cheap on normal PRs.
+#
+# Checks performed when schema files change:
+#   1. Alembic model sync  — `alembic check` ensures every model change has a migration
+#   2. Backward compat     — scans new migration files for dangerous patterns
+#      (DROP COLUMN, NOT NULL without DEFAULT, column renames without deprecation)
+#
+# Caller pattern:
+#   jobs:
+#     schema-check:
+#       uses: wcmchenry3-stack/.github/.github/workflows/called-schema-migration.yml@main
+#       with:
+#         working-directory: backend      # directory containing alembic.ini
+#         python-version: '3.11'          # optional, default '3.11'
+#
+# Applies to repos with Alembic migrations. For SQLAlchemy-only repos (no alembic.ini),
+# the alembic-check step is skipped and only the backward-compat grep runs.
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: 'Directory containing alembic.ini (or models if no Alembic)'
+        type: string
+        default: '.'
+      python-version:
+        description: 'Python version'
+        type: string
+        default: '3.11'
+
+jobs:
+  schema-migration:
+    name: Schema migration check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0     # full history needed to diff against base branch
+
+      # ------------------------------------------------------------------
+      # 1. Detect whether schema/migration/model files changed in this PR
+      # ------------------------------------------------------------------
+      - name: Detect schema changes
+        id: detect
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null \
+            | grep -iE '(migration|alembic|models?\.py|schema\.py|schema\.sql|\.sql)' \
+            | grep -v '__pycache__' \
+            || true)
+
+          if [ -n "$CHANGED" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Schema-related files changed:"
+            echo "$CHANGED"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No schema/migration files changed — skipping checks."
+          fi
+
+      # ------------------------------------------------------------------
+      # 2. Alembic model sync check
+      #    `alembic check` exits non-zero if the model is ahead of migrations
+      # ------------------------------------------------------------------
+      - name: Set up Python
+        if: steps.detect.outputs.changed == 'true'
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install dependencies
+        if: steps.detect.outputs.changed == 'true'
+        run: pip install -r requirements.txt
+        working-directory: ${{ inputs.working-directory }}
+
+      - name: Alembic model sync check
+        if: steps.detect.outputs.changed == 'true'
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          # Alembic needs a DB URL — use SQLite in-memory for the sync check
+          DATABASE_URL: "sqlite:///./test_migration_check.db"
+        run: |
+          if [ ! -f alembic.ini ]; then
+            echo "No alembic.ini found — skipping Alembic check (SQLAlchemy-only repo)."
+            exit 0
+          fi
+
+          echo "Running alembic upgrade to apply all migrations..."
+          alembic upgrade head
+
+          echo "Running alembic check to verify model matches migrations..."
+          if ! alembic check; then
+            echo ""
+            echo "::error::Model and migrations are out of sync."
+            echo "::error::A model was changed without a corresponding migration file."
+            echo "::error::Run: alembic revision --autogenerate -m 'describe_your_change'"
+            exit 1
+          fi
+
+          echo "Model and migrations are in sync."
+
+      # ------------------------------------------------------------------
+      # 3. Backward compatibility grep
+      #    Scans new migration files for patterns that would break on Render
+      #    (Render deploys new code before running migrations — old code must
+      #    still work against the new schema for the window between deploys)
+      # ------------------------------------------------------------------
+      - name: Backward compatibility check
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+
+          # Only scan lines added in this PR (+lines in new migration files)
+          NEW_MIGRATION_LINES=$(git diff "$BASE" "$HEAD" \
+            -- '*.py' '*.sql' \
+            | grep '^+' | grep -v '^+++' || true)
+
+          FAILURES=0
+
+          # DROP COLUMN — old code still reads the column during deploy window
+          if echo "$NEW_MIGRATION_LINES" | grep -iqE "op\.drop_column|DROP COLUMN"; then
+            echo "::warning::DROP COLUMN detected. Ensure old code no longer references this column before this migration runs. Use a two-phase approach: remove code reference first, then drop column in a follow-up migration."
+          fi
+
+          # NOT NULL column without server_default — will fail on existing rows
+          if echo "$NEW_MIGRATION_LINES" | grep -iqE "nullable=False" && \
+             ! echo "$NEW_MIGRATION_LINES" | grep -iqE "server_default|default="; then
+            echo "::error::NOT NULL column added without a server_default or default value."
+            echo "::error::Existing rows will fail the constraint. Add server_default='' or make the column nullable first."
+            FAILURES=$((FAILURES + 1))
+          fi
+
+          # Column rename without deprecation (drop + add in same migration)
+          if echo "$NEW_MIGRATION_LINES" | grep -iqE "op\.drop_column" && \
+             echo "$NEW_MIGRATION_LINES" | grep -iqE "op\.add_column"; then
+            echo "::warning::Column rename pattern detected (drop + add in same migration). Ensure old code does not reference the dropped column during the deploy window."
+          fi
+
+          if [ "$FAILURES" -gt 0 ]; then
+            echo ""
+            echo "::error::$FAILURES backward compatibility issue(s) found. Fix before merging — Render deploys new code before running migrations."
+            exit 1
+          fi
+
+          echo "Backward compatibility check passed."

--- a/.github/workflows/sync-community-health.yml
+++ b/.github/workflows/sync-community-health.yml
@@ -104,6 +104,8 @@ jobs:
                   '.github/workflows/gemini-policy.yml',
               'community-health/workflows/design-token-check.yml':
                   '.github/workflows/design-token-check.yml',
+              'community-health/workflows/schema-migration.yml':
+                  '.github/workflows/schema-migration.yml',
           }
 
           def api(path, method='GET', body=None):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,37 @@ These are intentionally repo-specific and should **not** be upstreamed:
 
 All other repos: fully synced, no local additions.
 
+## CI hardening lessons
+
+Lessons from real incidents in org repos — follow these to avoid the fix-the-fix chain anti-pattern.
+
+### Always use `npm ci`, never `npm install`
+
+`npm ci` installs from `package-lock.json` exactly, catching lockfile drift and preventing
+"works locally, breaks in CI" failures. All reusable workflows already enforce this.
+
+### `pod install` requires retry logic
+
+CocoaPods CDN (`cdn.cocoapods.org`) has transient timeouts. Both `called-ios-build-check.yml`
+and `called-ios-e2e.yml` already wrap `pod install` in a 3-attempt retry loop with backoff.
+Any new iOS workflow must include the same pattern.
+
+### Test CI scripts against a clean environment first
+
+Lesson from gaming_app PRs #82–#86 — five consecutive PRs each fixing a side effect of the
+previous one (missing Node.js on runner, wrong PATH, circular symlink). One test on a fresh
+runner would have caught all of it. Before merging a new workflow:
+
+1. Run it on a throwaway branch against a real runner.
+2. Verify it starts from a clean state (no cached `node_modules`, no existing Pods).
+3. Batch all fixes into one PR — never chain "fix the fix" PRs.
+
+### Never use `npm install` in Render deploy scripts
+
+Render's build environment mirrors `npm ci` behavior. Using `npm install` in a deploy
+script can silently resolve different versions than CI tested against. The
+`called-render-preflight.yml` workflow explicitly validates this before deploy.
+
 ## Conventions
 
 - Workflows are prefixed `called-` and use `workflow_call` triggers.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ All workflows are prefixed `called-` and use `on: workflow_call`. Call them from
 | `called-wikipedia-policy.yml` | Wikimedia API compliance check — restricted to `office_holder_cursor` |
 | `called-design-token-check.yml` | Design tokens and WCAG 2.2 AA checks for frontend code |
 | `called-commitlint.yml` | Enforces Conventional Commits format on PR titles |
+| `called-schema-migration.yml` | Schema/migration change detection, Alembic model sync, backward compat grep |
 
 ## Caller Pattern
 
@@ -89,6 +90,7 @@ by `sync-community-health.yml` whenever they change on `main`.
 | `community-health/workflows/openai-policy.yml` | `.github/workflows/openai-policy.yml` |
 | `community-health/workflows/gemini-policy.yml` | `.github/workflows/gemini-policy.yml` |
 | `community-health/workflows/design-token-check.yml` | `.github/workflows/design-token-check.yml` |
+| `community-health/workflows/schema-migration.yml` | `.github/workflows/schema-migration.yml` |
 
 ## Claude Code Tooling
 

--- a/community-health/workflows/schema-migration.yml
+++ b/community-health/workflows/schema-migration.yml
@@ -1,0 +1,12 @@
+name: Schema Migration Check
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  schema-check:
+    uses: wcmchenry3-stack/.github/.github/workflows/called-schema-migration.yml@main
+    with:
+      working-directory: backend
+      python-version: '3.11'


### PR DESCRIPTION
## Summary

Closes #19 and #35.

### #35 — `called-schema-migration.yml`

New reusable workflow that only fires when schema/migration/model files actually change in a PR. Three checks:

1. **Schema change detection** — diffs PR head vs base, looks for `migration`, `alembic`, `models.py`, `schema.py`, `.sql` files; skips remaining steps if nothing matches
2. **Alembic model sync** (`alembic check`) — verifies every model change has a corresponding migration; exits non-zero with a clear error if out of sync. Skipped gracefully if no `alembic.ini` (SQLAlchemy-only repos)
3. **Backward compat grep** — scans new migration lines for patterns that would break during Render's deploy window (new code runs before migrations complete):
   - `DROP COLUMN` → warning (two-phase approach required)
   - `NOT NULL` without `server_default` → error (existing rows fail)
   - Column rename pattern (drop + add) → warning

**Caller stub** (`community-health/workflows/schema-migration.yml`) added to FILE_MAP — will sync to `book_app`, `gaming_app`, `office_holder_cursor` on next community health sync. Each repo should adjust `working-directory` as needed.

### #19 — CI hardening lessons in CLAUDE.md

Documented the four lessons from real org incidents:
- Always `npm ci`, never `npm install`
- `pod install` retry pattern (already in iOS workflows)
- Test CI scripts on a clean environment — never chain fix-the-fix PRs
- Never use `npm install` in Render deploy scripts

## Test plan

- [ ] Trigger on a PR in `book_app` that touches `backend/alembic/versions/` — confirm schema check fires
- [ ] Trigger on a PR with no schema files changed — confirm all steps are skipped
- [ ] Add a model field without a migration in `book_app` — confirm `alembic check` fails with clear message
- [ ] Add a `NOT NULL` column without `server_default` — confirm backward compat check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)