### PR TITLE
fix(policy-gate): skip test/spec files and anchor pr-create verb check

### DIFF
--- a/.claude/hooks/policy-gate.sh
+++ b/.claude/hooks/policy-gate.sh
@@ -8,8 +8,8 @@ set -uo pipefail
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
-# Only gate on PR-creation commands
-if ! echo "$COMMAND" | grep -qE 'gh\s+pr\s+create'; then
+# Only gate on PR-creation commands (anchored to start to avoid matching --body text)
+if ! echo "$COMMAND" | grep -qE '^gh\s+pr\s+create'; then
   exit 0
 fi
 

--- a/.claude/policies/policy-patterns.json
+++ b/.claude/policies/policy-patterns.json
@@ -1,19 +1,19 @@
 {
   "openai": {
     "detect": "from openai|import openai|openai\\.com|OpenAI\\(|client\\.chat\\.completions|client\\.completions\\.create|OPENAI_API_KEY",
-    "skip": "^\\.env"
+    "skip": "^\\.env|\\.test\\.[jt]sx?$|\\.spec\\.[jt]sx?$"
   },
   "wikipedia": {
     "detect": "wikipedia\\.org|mediawiki|wikimedia",
-    "skip": null
+    "skip": "\\.test\\.[jt]sx?$|\\.spec\\.[jt]sx?$"
   },
   "gemini": {
     "detect": "google\\.generativeai|from google.*generativeai|genai\\.|GenerativeModel|GEMINI_API_KEY|GOOGLE_AI_API_KEY",
-    "skip": "^\\.env"
+    "skip": "^\\.env|\\.test\\.[jt]sx?$|\\.spec\\.[jt]sx?$"
   },
   "claude": {
     "detect": "from anthropic|import anthropic|@anthropic-ai/sdk|Anthropic\\(|ANTHROPIC_API_KEY|claude_agent_sdk",
-    "skip": "^\\.env"
+    "skip": "^\\.env|\\.test\\.[jt]sx?$|\\.spec\\.[jt]sx?$"
   },
   "design-tokens": {
     "detect": ":\\s*#[0-9a-fA-F]{3,8}|rgba?\\s*\\(|hsla?\\s*\\(|font-size:\\s*[0-9]+px|font-family:\\s*[\"']|tabindex=[\"'][1-9]",


### PR DESCRIPTION
## Summary
- All four API policies (`openai`, `wikipedia`, `gemini`, `claude`) had no skip patterns for test/spec files, causing false positives on any `*.test.ts` / `*.spec.ts` change
- The `gh pr create` guard matched against the full command string including `--body` text, blocking `gh issue create` calls whose body mentioned "gh pr create"

## Changes
- **`policy-patterns.json`** — added `\.test\.[jt]sx?$|\.spec\.[jt]sx?$` skip to `openai`, `wikipedia`, `gemini`, `claude` (matches the existing pattern already on `design-tokens`)
- **`policy-gate.sh`** — anchored the `gh pr create` detection to `^` so body text can't trigger it

## Syncs to all repos via `sync-community-health.yml` on merge

Closes #134

## Test plan
- [ ] Confirm `gh pr create` still fires the hook normally
- [ ] Confirm `gh issue create --body "...gh pr create..."` is no longer blocked
- [ ] Confirm a branch that only changes `*.test.ts` files is no longer blocked by openai/wikipedia/gemini/claude policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)