### PR TITLE
chore: rename gaming_app → BC-Arcade, book_app → BookshelfAI, office_holder_cursor → RulersAI in org config

### DIFF
--- a/.github/policy-enforcement.yml
+++ b/.github/policy-enforcement.yml
@@ -24,7 +24,7 @@ defaults:
 # Per-repo overrides. Uncomment and set to `required` when the repo
 # begins calling the API. Repo key is the bare repo name (no owner).
 overrides: {}
-  # book_app:
+  # BookshelfAI:
   #   openai: required
-  # office_holder_cursor:
+  # RulersAI:
   #   gemini: required

--- a/.github/workflows/scheduled-workflow-failure-monitor.yml
+++ b/.github/workflows/scheduled-workflow-failure-monitor.yml
@@ -21,7 +21,7 @@ jobs:
           ORG: wcmchenry3-stack
         run: |
           # Repos to monitor (space-separated)
-          REPOS="gaming_app office_holder_cursor powerplayshistory_site book_app wcm_portfolio_site buffingchi_site"
+          REPOS="BC-Arcade RulersAI powerplayshistory_site BookshelfAI wcm_portfolio_site buffingchi_site"
 
           # Look back window: last 25 hours to avoid gaps between runs
           SINCE=$(date -u -d '25 hours ago' '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \

--- a/.github/workflows/sync-community-health.yml
+++ b/.github/workflows/sync-community-health.yml
@@ -5,7 +5,7 @@ name: Sync Community Health Files
 #
 # Required secret: COMMUNITY_HEALTH_SYNC_PAT
 #   Fine-grained PAT with Contents: write + Pull requests: write on all repos
-#   listed in the matrix below: gaming_app, office_holder_cursor, book_app,
+#   listed in the matrix below: BC-Arcade, RulersAI, BookshelfAI,
 #   powerplayshistory_site, wcm_portfolio_site, buffingchi_site.
 #   A classic PAT with `repo` scope also works.
 
@@ -31,9 +31,9 @@ jobs:
       fail-fast: false
       matrix:
         repo:
-          - gaming_app
-          - office_holder_cursor
-          - book_app
+          - BC-Arcade
+          - RulersAI
+          - BookshelfAI
           - powerplayshistory_site
           - wcm_portfolio_site
           - buffingchi_site


### PR DESCRIPTION
## Summary

Follows three GitHub repo renames. GitHub redirects old URLs automatically, so existing clones and web links are unaffected.

| Old name | New name |
|----------|----------|
| `gaming_app` | `BC-Arcade` |
| `book_app` | `BookshelfAI` |
| `office_holder_cursor` | `RulersAI` |

**Files updated:**
- `.github/workflows/sync-community-health.yml` — matrix entries + comment
- `.github/workflows/scheduled-workflow-failure-monitor.yml` — REPOS list
- `.github/policy-enforcement.yml` — commented override examples

> Supersedes PR #144 which only covered the RulersAI rename — please close that one in favour of this.

## Test plan

- [ ] Confirm sync-community-health matrix targets all three new names
- [ ] Confirm failure monitor REPOS list uses all three new names
- [ ] Confirm policy-enforcement comments are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)