### PR TITLE
fix(zap): fix startup_failure by removing Unicode and secret-to-output leak

### DIFF
--- a/.github/workflows/called-zap-scheduled.yml
+++ b/.github/workflows/called-zap-scheduled.yml
@@ -13,9 +13,7 @@ on:
         type: string
         required: true
       branches:
-        description: >
-          Comma-separated list of branches that should run the scan.
-          Leave empty to always run (default). Example: "main,dev"
+        description: 'Comma-separated branches to scan, e.g. "main,dev". Leave empty to always run.'
         type: string
         required: false
         default: ''
@@ -33,7 +31,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Guard – branch filter
+      - name: Guard - branch filter
         id: guard
         run: |
           BRANCHES="${{ inputs.branches }}"
@@ -44,25 +42,17 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "⏭ Skipping ZAP scan: branch '$CURRENT' not in [$BRANCHES]"
+            echo "Skipping ZAP scan: branch '$CURRENT' not in [$BRANCHES]"
           fi
-      - name: Resolve scan URL
-        id: scan-url
-        run: |
-          URL="${{ secrets.target-url-secret }}"
-          if [ -z "$URL" ]; then
-            URL="${{ inputs.target-url }}"
-          fi
-          echo "value=$URL" >> "$GITHUB_OUTPUT"
       - name: Run ZAP baseline scan
-        if: ${{ steps.guard.outputs.run == 'true' && steps.scan-url.outputs.value != '' }}
+        if: ${{ steps.guard.outputs.run == 'true' && (secrets.target-url-secret != '' || inputs.target-url != '') }}
         uses: zaproxy/action-baseline@v0.15.0
         with:
-          target: ${{ steps.scan-url.outputs.value }}
+          target: ${{ secrets.target-url-secret || inputs.target-url }}
           fail_action: false
       - name: Upload ZAP report
+        if: ${{ steps.guard.outputs.run == 'true' && (secrets.target-url-secret != '' || inputs.target-url != '') }}
         uses: actions/upload-artifact@v7
-        if: ${{ steps.guard.outputs.run == 'true' && steps.scan-url.outputs.value != '' }}
         with:
           name: ${{ inputs.artifact-name }}-${{ github.run_id }}
           path: report_html.html


### PR DESCRIPTION
## Problem

The ZAP weekly scan has been failing with `startup_failure` (0 jobs, no logs) across all 4 app repos since April 12 — five consecutive Sundays of silent failures. The scans have **never successfully run** in the current configuration.

## Root causes (all introduced April 11)

| # | Issue | Detail |
|---|---|---|
| 1 | Unicode en-dash in step name | `Guard – branch filter` uses U+2013 (–), which GitHub Actions' YAML schema validator rejects |
| 2 | YAML folded scalar with embedded quotes | `description: >` containing `Example: "main,dev"` was ambiguous to GitHub's parser |
| 3 | Secret written to `$GITHUB_OUTPUT` | The `Resolve scan URL` step echoed `${{ secrets.target-url-secret }}` to step outputs — GitHub Actions can reject this pattern at validation time as a security violation |

## Changes

- **Remove `Resolve scan URL` step** — no more intermediate step writing secrets to `$GITHUB_OUTPUT`
- **Inline URL resolution** — use `${{ secrets.target-url-secret || inputs.target-url }}` directly in the `zaproxy` step's `target:` field
- **ASCII step name** — `Guard – branch filter` → `Guard - branch filter` (hyphen)
- **Single-line description** — `branches` input uses inline string instead of `description: >` folded scalar
- **Remove emoji** — `⏭` replaced with plain text in the skip echo

## Callers unaffected

All four app repo `zap-scan.yml` files are unchanged. Callers using `target-url` (hardcoded) or `target-url-secret` both continue to work via the new inline `||` resolution.

## Test plan
- [ ] Merge to `main` and manually dispatch `ZAP Weekly Scan` on BC-Arcade via `gh workflow run`
- [ ] Confirm run reaches the `ZAP baseline scan` step (not `startup_failure`)
- [ ] Confirm artifact is uploaded on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)