### PR TITLE
fix(ci): revert ZAP action versions to v4, block phantom Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    ignore:
+      # v5+ does not exist; latest is v4
+      - dependency-name: "actions/checkout"
+        versions: [">=5"]
+      # v5+ does not exist; latest is v4
+      - dependency-name: "actions/upload-artifact"
+        versions: [">=5"]
 
   # Cloudflare Email Worker (Node.js)
   - package-ecosystem: "npm"

--- a/.github/workflows/called-zap-scheduled.yml
+++ b/.github/workflows/called-zap-scheduled.yml
@@ -30,7 +30,7 @@ jobs:
       issues: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Guard - branch filter
         id: guard
         run: |
@@ -52,7 +52,7 @@ jobs:
           fail_action: false
       - name: Upload ZAP report
         if: ${{ steps.guard.outputs.run == 'true' && (secrets.target-url-secret != '' || inputs.target-url != '') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}-${{ github.run_id }}
           path: report_html.html


### PR DESCRIPTION
## Summary

- Dependabot PRs #180 and #182 bumped `actions/checkout` → v6 and `actions/upload-artifact` → v7, neither of which exist (latest for both is v4). This caused the ZAP scheduled scan to fail with `startup_failure` / zero jobs on every run since April 12.
- Reverts both to `@v4`.
- Adds `ignore` rules in `dependabot.yml` for `>=5` on each action to prevent Dependabot from re-proposing the same non-existent versions.

## Test plan

- [ ] Merge this PR to `main`
- [ ] Trigger `workflow_dispatch` on `BC-Arcade/zap-scan.yml` and confirm the scan completes with jobs executing

Closes wcmchenry3-stack/BC-Arcade#1955

🤖 Generated with [Claude Code](https://claude.com/claude-code)