### PR TITLE
fix(ci): add checkout step to called-sync-main-to-dev.yml

### DIFF
--- a/.github/workflows/called-sync-main-to-dev.yml
+++ b/.github/workflows/called-sync-main-to-dev.yml
@@ -11,6 +11,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: Open draft sync PR
         run: |
           if gh pr list --base dev --head main --state open --json number --jq '.[0].number' | grep -q '[0-9]'; then


### PR DESCRIPTION
## Summary

- Adds `actions/checkout@v4` before the `gh pr list` / `gh pr create` step in `called-sync-main-to-dev.yml`
- `gh pr list` invokes git internally; without a checkout the runner has no `.git` directory and exits with `fatal: not a git repository`

Closes wcmchenry3-stack/BC-Arcade#1998

## Test plan

- [ ] Merge something to `main` on BC-Arcade after this merges — confirm the **sync / Open sync PR (main to dev)** job passes and a draft PR is opened (or skipped if one already exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)