### PR TITLE
fix(lint-python): pin black/ruff versions instead of installing latest

### DIFF
--- a/.github/workflows/called-lint-python.yml
+++ b/.github/workflows/called-lint-python.yml
@@ -9,6 +9,14 @@ on:
       working-directory:
         type: string
         default: '.'
+      black-version:
+        description: 'Pinned black version. Unpinned "pip install black ruff" let upstream rule changes silently break lint-python on unrelated PRs — see wcmchenry3-stack/BookshelfAI#403.'
+        type: string
+        default: '26.5.1'
+      ruff-version:
+        description: 'Pinned ruff version. Unpinned "pip install black ruff" let upstream rule changes silently break lint-python on unrelated PRs — see wcmchenry3-stack/BookshelfAI#403.'
+        type: string
+        default: '0.15.20'
 
 jobs:
   lint-python:
@@ -20,7 +28,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install linters
-        run: pip install black ruff
+        run: pip install black==${{ inputs.black-version }} ruff==${{ inputs.ruff-version }}
       - name: black
         run: black --check .
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
## Problem
`called-lint-python.yml` runs `pip install black ruff` with no version pin, so every consumer repo installs whatever is newest on PyPI at CI run time. When ruff (or black) ships new default-enabled rules, previously-clean code starts failing lint with zero code changes on the consumer's side.

Concretely: this silently broke `lint-python` on `wcmchenry3-stack/BookshelfAI`'s `dev` branch (61 new findings across 23 backend files, unrelated to any pending PR's diff), which in turn skipped every downstream required check (`sast-python`, `test-migrations`, `test-python`, `test-frontend`) via `needs:", permanently blocking all open dependabot PRs.

## Fix
Add `black-version` / `ruff-version` inputs, defaulted to the versions already pinned in BookshelfAI's `backend/requirements-dev.txt` (black 26.5.1, ruff 0.15.20), and install those explicitly instead of `pip install black ruff`.

Consumers that don't pass these inputs get the pinned defaults (fixing the drift bug for them too); BookshelfAI's `ci.yml` will pass explicit values so its own requirements-dev.txt stays the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuJa5P5567YhvEc6otAxEv