### PR TITLE
feat(dependabot-triage): nightly Dependabot triage agent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,17 @@ updates:
     labels:
       - "dependencies"
       - "ci"
+    groups:
+      # CVE fixes get their own PR so they are never held up behind a routine batch.
+      security-updates:
+        applies-to: security-updates
+        patterns: ["*"]
+      # Minor/patch action bumps batch into one PR; majors still open
+      # individually, since an action major can change inputs or runtime.
+      actions:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     ignore:
       # v5+ does not exist; latest is v4
       - dependency-name: "actions/checkout"
@@ -30,3 +41,30 @@ updates:
       prefix: "chore"
     labels:
       - "dependencies"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns: ["*"]
+      minor-and-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # Dependabot triage agent (Python)
+  - package-ecosystem: "pip"
+    directory: "/dependabot-triage"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns: ["*"]
+      minor-and-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci-dependabot-triage.yml
+++ b/.github/workflows/ci-dependabot-triage.yml
@@ -1,0 +1,76 @@
+name: CI — Dependabot Triage
+
+# The triage agent is the only executable code in this meta-repo, and its guard
+# module decides whether an unattended merge may happen. That boundary must be
+# verified at review time, not only at 06:00 when the agent runs.
+
+on:
+  pull_request:
+    paths:
+      - "dependabot-triage/**"
+      - ".github/workflows/ci-dependabot-triage.yml"
+      - ".github/workflows/scheduled-dependabot-triage.yml"
+  push:
+    branches: [main]
+    paths:
+      - "dependabot-triage/**"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Lint and test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dependabot-triage
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: dependabot-triage/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-cov ruff black
+
+      - name: Ruff
+        run: ruff check .
+
+      - name: Black
+        run: black --check .
+
+      - name: Tests (80% floor)
+        run: python -m pytest tests -q
+
+      - name: Guard boundary must stay at 100%
+        # `-o addopts=""` clears the project-wide coverage flags from
+        # pyproject.toml so this measures guards.py alone rather than the whole
+        # package against the 80% floor.
+        run: |
+          python -m pytest tests -q -o addopts="" \
+            --cov=guards --cov-report=term-missing --cov-fail-under=100
+
+      - name: Config and schema are valid
+        run: |
+          python -c "
+          import json, pathlib, yaml
+          config = yaml.safe_load(pathlib.Path('config.yml').read_text())
+          json.loads(pathlib.Path('schema/assessment.schema.json').read_text())
+          for key in ('owner', 'repos', 'caps', 'timeouts', 'budget', 'models', 'effort'):
+              assert key in config, f'config.yml is missing {key!r}'
+          for prompt in ('assess', 'adversary', 'diagnose', 'summary'):
+              path = pathlib.Path('prompts') / f'{prompt}.md'
+              assert path.read_text().strip(), f'{path} is empty'
+          print('config, schema, and prompts OK')
+          "
+
+      - name: Entry point runs
+        # Catches an import-time break in a module the unit tests do not import.
+        run: python __main__.py --help

--- a/.github/workflows/scheduled-dependabot-triage.yml
+++ b/.github/workflows/scheduled-dependabot-triage.yml
@@ -60,10 +60,16 @@ jobs:
         # The guards decide whether a merge may happen. If their tests do not
         # pass, the run must not proceed — a broken boundary is worse than no
         # automation at all.
+        #
+        # `-o addopts=""` clears the project-wide coverage flags from
+        # pyproject.toml so this gate measures guards.py alone at 100%, rather
+        # than the whole package against the 80% floor.
         run: |
           pip install pytest pytest-cov
           cd dependabot-triage
-          python -m pytest tests -q --cov=guards --cov-fail-under=100
+          python -m pytest tests -q                       # full suite, 80% floor
+          python -m pytest tests -q -o addopts="" \
+            --cov=guards --cov-report=term --cov-fail-under=100
 
       - name: Run triage
         env:

--- a/.github/workflows/scheduled-dependabot-triage.yml
+++ b/.github/workflows/scheduled-dependabot-triage.yml
@@ -1,0 +1,110 @@
+name: Scheduled Dependabot Triage
+
+# Runs at 06:00 UTC — 1am CDT, midnight CST. GitHub cron has no DST handling, so
+# the local time shifts by an hour twice a year; that is immaterial for an
+# overnight job.
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Assess and report without commenting, rebasing, or merging"
+        type: boolean
+        default: true
+      repos:
+        description: "Comma-separated subset of repos (blank = all enabled in config.yml)"
+        type: string
+        default: ""
+      verbose:
+        description: "Debug logging"
+        type: boolean
+        default: false
+
+concurrency:
+  group: dependabot-triage
+  cancel-in-progress: false
+
+permissions:
+  contents: write # commit the metrics history to THIS repo only
+  actions: read
+
+jobs:
+  triage:
+    name: Triage Dependabot PRs
+    runs-on: ubuntu-latest
+    # Slightly above the script's own 4h wall-clock budget so the script always
+    # gets to write its ledger and send the email rather than being killed.
+    timeout-minutes: 260
+
+    steps:
+      - name: Halt if the kill switch is set
+        run: |
+          if [ -f HOLD ]; then
+            echo "::warning::HOLD file present at repo root — skipping this run"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: dependabot-triage/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r dependabot-triage/requirements.txt
+
+      - name: Verify the guard boundary before trusting it
+        # The guards decide whether a merge may happen. If their tests do not
+        # pass, the run must not proceed — a broken boundary is worse than no
+        # automation at all.
+        run: |
+          pip install pytest pytest-cov
+          cd dependabot-triage
+          python -m pytest tests -q --cov=guards --cov-fail-under=100
+
+      - name: Run triage
+        env:
+          # Pay-as-you-go API billing, deliberately separate from any Claude Code
+          # subscription so this job can never consume interactive usage.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          # Scoped fine-grained PAT: pull-requests + contents on the target repos,
+          # deliberately without Administration or Actions permissions, so the job
+          # cannot alter branch protection or disable a workflow.
+          GH_TOKEN: ${{ secrets.DEPENDABOT_TRIAGE_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          cd dependabot-triage
+          python __main__.py \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) && '--no-dry-run' || '--dry-run' }} \
+            ${{ inputs.repos != '' && format('--repos {0}', inputs.repos) || '' }} \
+            ${{ inputs.verbose && '--verbose' || '' }}
+
+      - name: Upload ledger
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: triage-ledger-${{ github.run_id }}
+          path: dependabot-triage/out/ledger.json
+          retention-days: 90
+
+      - name: Commit metrics history
+        if: always()
+        # Uses the default GITHUB_TOKEN, which is scoped to this repository only
+        # and has no access to any target repo — the two credentials stay separate.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          if [ -z "$(git status --porcelain dependabot-triage/history)" ]; then
+            echo "no history changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dependabot-triage/history
+          git commit -m "chore(triage): record run ${{ github.run_id }} [skip ci]"
+          git push

--- a/dependabot-triage/.gitignore
+++ b/dependabot-triage/.gitignore
@@ -1,0 +1,14 @@
+# Python build and test artifacts
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/
+.venv/
+venv/
+
+# Run output — the ledger is uploaded as a workflow artifact, never committed.
+# The metrics history under history/ IS committed and is not ignored here.
+out/
+*.ledger.json

--- a/dependabot-triage/README.md
+++ b/dependabot-triage/README.md
@@ -1,0 +1,106 @@
+# Dependabot triage agent
+
+A nightly job that empties the low-risk Dependabot queue across the org, refuses
+anything it cannot justify, and sends one email covering every repo.
+
+Runs at 06:00 UTC via [`scheduled-dependabot-triage.yml`](../.github/workflows/scheduled-dependabot-triage.yml).
+
+## What it may and may not do
+
+The agent has exactly three side effects: **comment on a PR**, **ask Dependabot to
+rebase**, and **merge**. It never edits a file, never pushes a commit, and never
+touches branch protection. Rebases are performed by Dependabot in response to a
+comment, which is why the agent's token needs no write access to any target repo's
+git tree.
+
+That restriction is the point. The failure mode this design exists to prevent is
+an agent that, faced with a red CVE check, decides the check is the problem and
+turns it off. It cannot: there is no code path from here to a file edit, and the
+token has no `Administration` or `Actions` permission to reach for either.
+
+## Phases
+
+| Phase | Module | Model |
+|---|---|---|
+| 1. Harvest PRs + tamper baseline | `harvest.py` | none |
+| 2. Collective risk assessment | `assess.py` | Sonnet 5, one call for the whole stack |
+| 3. Decide, rebase, merge | `execute.py` | none |
+| 4. Diagnose failing checks | `diagnose.py` | Haiku 4.5 |
+| 5. Email the stack-wide report | `report.py` | Haiku 4.5, one paragraph only |
+| 6. Record history | `metrics.py` | none |
+
+The model classifies. Deterministic code decides. Phase 2's output is
+schema-validated data, and phase 3 maps it onto a four-value action vocabulary —
+so a model response can never be read as a command.
+
+## Guards
+
+`guards.py` holds eleven preconditions, re-run against freshly fetched API state
+immediately before every merge. Any failure means comment-and-skip.
+
+| ID | Refuses when |
+|---|---|
+| G01 | The author is not Dependabot |
+| G02 | A changed path is outside the manifest/lockfile/workflow allowlist |
+| G03 | A CI-defining file is touched (`pytest.ini`, `codecov.yml`, `.eslintrc*`, …) |
+| G04 | A `.github/workflows/` diff changes anything but a `uses:` version pin |
+| G05 | An added line matches a check-weakening pattern |
+| G06 | A required check is red, pending, or missing — or the repo requires none |
+| G07 | A required context disappeared from branch protection mid-run |
+| G08 | The head SHA moved since assessment |
+| G09 | A numeric quality gate was lowered |
+| G10 | GitHub does not consider the PR cleanly mergeable |
+| G11 | The `dependabot-triage:hold` label is present |
+
+Beyond the guards: an adversarial second opinion on every `LOW` (a different,
+weaker model arguing the merge is unsafe), per-repo and total merge caps, spend
+ceilings, and a tamper tripwire that aborts the run if any baseline drifts.
+
+`guards.py` is held at **100% coverage**, verified in CI before the agent is
+allowed to run. A broken boundary is worse than no automation.
+
+## Running locally
+
+```bash
+pip install -r requirements.txt
+python __main__.py --dry-run --verbose            # assess and report, change nothing
+python __main__.py --dry-run --repos RulersAI     # one repo
+python __main__.py --no-dry-run                   # live
+```
+
+`--dry-run` is the default everywhere, including the workflow. Going live is an
+explicit `workflow_dispatch` choice.
+
+## Tests
+
+```bash
+python -m pytest                                   # 80% floor, enforced
+python -m pytest --cov=guards --cov-fail-under=100 # the boundary
+```
+
+`gh.py` and `llm.py` are excluded from coverage: they are pure adapters over the
+`gh` CLI and the Anthropic SDK, and unit tests over them would assert the
+behaviour of a mock. They are exercised by the dry run against live repos.
+
+## Configuration
+
+Everything tunable lives in [`config.yml`](config.yml). Repos are opted in
+individually and ship disabled apart from `powerplayshistory_site`, which is the
+staged-rollout starting point.
+
+## Secrets
+
+| Secret | Used for |
+|---|---|
+| `ANTHROPIC_API_KEY` | Model calls. Pay-as-you-go API billing, deliberately separate from any Claude Code subscription — this job cannot consume interactive usage. |
+| `RESEND_API_KEY` | The nightly email. One message a day sits far inside Resend's free tier. |
+| `DEPENDABOT_TRIAGE_TOKEN` | Cross-repo PR access. Fine-grained, `Pull requests: RW` + `Contents: RW` + `Metadata: R`, and deliberately **no** `Administration` or `Actions`. |
+
+The workflow's own `GITHUB_TOKEN` commits the metrics history and is scoped to
+this repository only, so the two credentials stay separate.
+
+## Kill switches
+
+- `dependabot-triage:hold` label on a PR — skips that PR.
+- `HOLD` file at the root of this repo — halts the whole run.
+- `enabled: false` in `config.yml` — skips a repo before any API call.

--- a/dependabot-triage/__main__.py
+++ b/dependabot-triage/__main__.py
@@ -1,0 +1,265 @@
+"""Entry point. Wires the phases together and guarantees the email always goes out.
+
+Run order: harvest -> assess -> execute -> diagnose -> record -> report. Any
+failure after harvest still produces a report explaining what stopped, because a
+silent night is indistinguishable from a healthy one and that is how automation
+quietly rots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+import assess as assess_mod
+import diagnose as diagnose_mod
+import execute as execute_mod
+import gh
+import guards
+import harvest as harvest_mod
+import metrics
+import report as report_mod
+from budget import Budget, BudgetExceeded
+from llm import Client, ModelResponseInvalid
+from models import Action
+
+HERE = Path(__file__).parent
+log = logging.getLogger("triage")
+
+
+def load_config(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def check_tripwires(harvests: list[harvest_mod.RepoHarvest], owner: str) -> list[str]:
+    """Re-check every tamper baseline. Any drift ends the run.
+
+    This is the layer that catches a required check disappearing, a workflow file
+    changing, or a coverage threshold dropping while the run was in flight —
+    whatever the cause.
+    """
+    problems: list[str] = []
+    for h in harvests:
+        live_contexts = gh.required_contexts(h.repo, owner, h.base)
+        result = guards.guard_protection_unchanged(h.baseline, live_contexts)
+        if not result.passed:
+            problems.append(f"{h.repo}: {result.detail}")
+
+        live_shas = gh.file_shas(h.repo, owner, ".github/workflows", h.base)
+        for path, sha in h.baseline.workflow_file_shas.items():
+            if live_shas.get(path) != sha:
+                problems.append(f"{h.repo}: workflow {path} changed during the run")
+
+        live_thresholds: dict[str, float] = {}
+        for path in list(live_shas) + ["pyproject.toml", "package.json"]:
+            text = gh.file_text(h.repo, owner, path, h.base)
+            for key, value in guards.extract_thresholds(text).items():
+                live_thresholds[key] = max(live_thresholds.get(key, value), value)
+        ratchet = guards.guard_thresholds_not_lowered(h.baseline, live_thresholds)
+        if not ratchet.passed:
+            problems.append(f"{h.repo}: {ratchet.detail}")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="dependabot-triage")
+    parser.add_argument("--config", type=Path, default=HERE / "config.yml")
+    parser.add_argument(
+        "--dry-run",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="assess and report without commenting, rebasing, or merging",
+    )
+    parser.add_argument("--repos", default="", help="comma-separated subset of configured repos")
+    parser.add_argument("--run-url", default=os.environ.get("RUN_URL", ""))
+    parser.add_argument("--run-id", default=os.environ.get("GITHUB_RUN_ID", "local"))
+    parser.add_argument("--ledger", type=Path, default=HERE / "out" / "ledger.json")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+    )
+
+    config = load_config(args.config)
+    if args.repos:
+        wanted = {name.strip() for name in args.repos.split(",") if name.strip()}
+        for entry in config["repos"]:
+            entry["enabled"] = entry["name"] in wanted
+
+    now = datetime.now(UTC)
+    owner = config["owner"]
+    aborted = ""
+
+    budget = Budget(
+        max_per_run=config["budget"]["max_per_run"],
+        max_per_month=config["budget"]["max_per_month"],
+        month_to_date=metrics.month_to_date_spend(now),
+    )
+
+    # --- Phase 1 ---------------------------------------------------------
+    harvests = harvest_mod.harvest_all(config)
+    open_prs = [pr for h in harvests for pr in h.dependabot_prs]
+
+    if not open_prs:
+        log.info("no open Dependabot PRs; exiting before any model call")
+        stats = metrics.summarise([])
+        body = report_mod.render_html(
+            summary="No open Dependabot pull requests tonight; nothing to do.",
+            decisions=[],
+            stats=stats,
+            rolling=metrics.rolling(),
+            precision=metrics.precision(),
+            budget=budget.summary(),
+            run_url=args.run_url,
+            when=now,
+            dry_run=args.dry_run,
+        )
+        report_mod.send(
+            body, report_mod.subject_line(stats, config, now), config, dry_run=args.dry_run
+        )
+        return 0
+
+    log.info("%d open Dependabot PR(s) across %d repo(s)", len(open_prs), len(harvests))
+
+    client = Client(budget, dry_run=args.dry_run)
+    result = execute_mod.ExecutionResult()
+
+    try:
+        # --- Phase 2 -----------------------------------------------------
+        assessments = assess_mod.assess(harvests, client, config)
+
+        # --- Phase 3 -----------------------------------------------------
+        result = execute_mod.execute(
+            harvests,
+            assessments,
+            client,
+            config,
+            run_url=args.run_url,
+            dry_run=args.dry_run,
+        )
+
+        # --- Phase 4 -----------------------------------------------------
+        by_repo = {h.repo: h for h in harvests}
+        for decision in result.decisions:
+            if decision.merged or decision.action is Action.MERGE:
+                continue
+            h = by_repo.get(decision.repo)
+            pr = next(
+                (p for p in (h.dependabot_prs if h else []) if p.number == decision.number),
+                None,
+            )
+            if pr is None or not pr.failing_required(h.baseline.required_contexts):
+                continue
+            try:
+                decision.diagnosis = diagnose_mod.diagnose(
+                    pr, h.baseline.required_contexts, client, config, dry_run=args.dry_run
+                )
+            except (BudgetExceeded, ModelResponseInvalid) as exc:
+                log.warning("diagnosis skipped for %s: %s", pr.slug, exc)
+
+        # --- Tripwires ---------------------------------------------------
+        if not args.dry_run:
+            problems = check_tripwires(harvests, owner)
+            if problems:
+                aborted = "tamper tripwire fired — " + "; ".join(problems)
+                log.error(aborted)
+
+    except BudgetExceeded as exc:
+        aborted = str(exc)
+        log.error("budget ceiling hit: %s", exc)
+    except ModelResponseInvalid as exc:
+        aborted = f"model response was unusable: {exc}"
+        log.error(aborted)
+    except gh.GhError as exc:
+        aborted = f"GitHub API failure: {exc}"
+        log.error(aborted)
+
+    # --- Phase 6 ---------------------------------------------------------
+    stats = metrics.summarise(result.decisions)
+    metrics.record_run(
+        result.decisions,
+        budget.summary(),
+        run_id=args.run_id,
+        now=now,
+        dry_run=args.dry_run,
+    )
+
+    args.ledger.parent.mkdir(parents=True, exist_ok=True)
+    args.ledger.write_text(
+        json.dumps(
+            {
+                "run_id": args.run_id,
+                "at": now.isoformat(),
+                "dry_run": args.dry_run,
+                "aborted": aborted,
+                "stats": stats,
+                "budget": budget.summary(),
+                "decisions": [
+                    {
+                        "repo": d.repo,
+                        "number": d.number,
+                        "title": d.title,
+                        "tier": d.tier.value,
+                        "action": d.action.value,
+                        "reason": d.reason,
+                        "merged": d.merged,
+                        "rebased": d.rebased,
+                        "deferred": d.deferred,
+                        "deciding_question": d.deciding_question,
+                        "diagnosis": d.diagnosis,
+                        "guards": [
+                            {"id": g.guard_id, "passed": g.passed, "detail": g.detail}
+                            for g in d.guard_results
+                        ],
+                    }
+                    for d in result.decisions
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    log.info("ledger written to %s", args.ledger)
+
+    # --- Phase 5 ---------------------------------------------------------
+    summary = report_mod.compose_summary(stats, client, config, aborted=aborted)
+    body = report_mod.render_html(
+        summary=summary,
+        decisions=result.decisions,
+        stats=stats,
+        rolling=metrics.rolling(now=now),
+        precision=metrics.precision(now=now),
+        budget=budget.summary(),
+        run_url=args.run_url,
+        when=now,
+        dry_run=args.dry_run,
+        aborted=aborted,
+    )
+    report_mod.send(
+        body,
+        report_mod.subject_line(stats, config, now, aborted=aborted),
+        config,
+        dry_run=args.dry_run,
+    )
+
+    log.info(
+        "done: %d merged, %d decisions, $%.4f spent",
+        stats["merged"],
+        stats["seen"],
+        budget.run_usd,
+    )
+    return 1 if aborted else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dependabot-triage/assess.py
+++ b/dependabot-triage/assess.py
@@ -35,7 +35,8 @@ def _describe_pr(pr: PullRequest, required: frozenset[str], base: str) -> str:
         f"### {pr.repo}#{pr.number}",
         f"title: {pr.title}",
         f"ecosystem: {pr.ecosystem}",
-        f"base branch: {base}" + ("  (merges here reach a Render deploy)" if base == "main" else ""),
+        f"base branch: {base}"
+        + ("  (merges here reach a Render deploy)" if base == "main" else ""),
         f"grouped: {'yes' if pr.is_group else 'no'}",
         f"labels: {', '.join(pr.labels) or 'none'}",
     ]
@@ -44,7 +45,9 @@ def _describe_pr(pr: PullRequest, required: frozenset[str], base: str) -> str:
     lines.append(f"changed files: {', '.join(pr.paths) or 'none'}")
 
     if required:
-        lines.append(f"required checks in this repo ({len(required)}): {', '.join(sorted(required))}")
+        lines.append(
+            f"required checks in this repo ({len(required)}): {', '.join(sorted(required))}"
+        )
     else:
         lines.append(
             "required checks in this repo: NONE — this repo's branch protection "
@@ -73,9 +76,7 @@ def build_corpus(harvests: list[RepoHarvest]) -> str:
             continue
         blocks.append(f"## Repository: {harvest.repo} (base: {harvest.base})")
         for pr in prs:
-            blocks.append(
-                _describe_pr(pr, harvest.baseline.required_contexts, harvest.base)
-            )
+            blocks.append(_describe_pr(pr, harvest.baseline.required_contexts, harvest.base))
     return "\n\n".join(blocks)
 
 
@@ -92,9 +93,7 @@ def _to_assessment(raw: dict) -> Assessment:
     )
 
 
-def assess(
-    harvests: list[RepoHarvest], client: Client, config: dict
-) -> dict[str, Assessment]:
+def assess(harvests: list[RepoHarvest], client: Client, config: dict) -> dict[str, Assessment]:
     """Classify every open Dependabot PR. Returns ``{"repo#number": Assessment}``.
 
     Any PR the model fails to return an assessment for is defaulted to MEDIUM —

--- a/dependabot-triage/assess.py
+++ b/dependabot-triage/assess.py
@@ -1,0 +1,203 @@
+"""Phase 2 — collective risk assessment, plus the adversarial second opinion.
+
+The assessment is one call over every PR in the stack so cross-repo and cross-PR
+reasoning (ordering, coupled families) is possible at all. Its output is
+schema-validated data; the executor never sees model prose.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from budget import should_chunk
+from harvest import RepoHarvest, parse_bump
+from llm import Client, ModelResponseInvalid
+from models import Assessment, PullRequest, RiskTier
+
+log = logging.getLogger(__name__)
+
+HERE = Path(__file__).parent
+SCHEMA = json.loads((HERE / "schema" / "assessment.schema.json").read_text(encoding="utf-8"))
+ASSESS_PROMPT = (HERE / "prompts" / "assess.md").read_text(encoding="utf-8")
+ADVERSARY_PROMPT = (HERE / "prompts" / "adversary.md").read_text(encoding="utf-8")
+
+# Dependabot embeds full release notes; enough to judge, not enough to blow the
+# context budget on a forty-PR night.
+BODY_CHARS = 3000
+
+
+def _describe_pr(pr: PullRequest, required: frozenset[str], base: str) -> str:
+    """Render one PR as the evidence block the rubric is applied to."""
+    package, from_v, to_v = parse_bump(pr.title)
+    lines = [
+        f"### {pr.repo}#{pr.number}",
+        f"title: {pr.title}",
+        f"ecosystem: {pr.ecosystem}",
+        f"base branch: {base}" + ("  (merges here reach a Render deploy)" if base == "main" else ""),
+        f"grouped: {'yes' if pr.is_group else 'no'}",
+        f"labels: {', '.join(pr.labels) or 'none'}",
+    ]
+    if package:
+        lines.append(f"package: {package} {from_v} -> {to_v}")
+    lines.append(f"changed files: {', '.join(pr.paths) or 'none'}")
+
+    if required:
+        lines.append(f"required checks in this repo ({len(required)}): {', '.join(sorted(required))}")
+    else:
+        lines.append(
+            "required checks in this repo: NONE — this repo's branch protection "
+            "requires no status checks, so a green PR proves very little here"
+        )
+
+    failing = [c.name for c in pr.checks if c.is_settled and not c.is_success]
+    lines.append(f"currently failing checks: {', '.join(failing) if failing else 'none'}")
+    lines.append(f"merge state: {pr.merge_state_status} / {pr.mergeable}")
+
+    for f in pr.files:
+        if f.path.startswith(".github/workflows/") and f.patch:
+            lines.append(f"workflow diff for {f.path}:\n{f.patch[:1200]}")
+
+    if pr.body:
+        lines.append(f"release notes (truncated):\n{pr.body[:BODY_CHARS]}")
+    return "\n".join(lines)
+
+
+def build_corpus(harvests: list[RepoHarvest]) -> str:
+    """Assemble the evidence for every open Dependabot PR across the stack."""
+    blocks: list[str] = []
+    for harvest in harvests:
+        prs = harvest.dependabot_prs
+        if not prs:
+            continue
+        blocks.append(f"## Repository: {harvest.repo} (base: {harvest.base})")
+        for pr in prs:
+            blocks.append(
+                _describe_pr(pr, harvest.baseline.required_contexts, harvest.base)
+            )
+    return "\n\n".join(blocks)
+
+
+def _to_assessment(raw: dict) -> Assessment:
+    return Assessment(
+        repo=raw["repo"],
+        number=int(raw["number"]),
+        tier=RiskTier(raw["tier"]),
+        merge_order=int(raw.get("merge_order", 0)),
+        rationale=raw.get("rationale", "").strip(),
+        deciding_question=raw.get("deciding_question", "NONE"),
+        evidence=raw.get("evidence", {}) or {},
+        packages=list(raw.get("packages") or []),
+    )
+
+
+def assess(
+    harvests: list[RepoHarvest], client: Client, config: dict
+) -> dict[str, Assessment]:
+    """Classify every open Dependabot PR. Returns ``{"repo#number": Assessment}``.
+
+    Any PR the model fails to return an assessment for is defaulted to MEDIUM —
+    a silent omission must never read as permission to merge.
+    """
+    corpus = build_corpus(harvests)
+    if not corpus:
+        return {}
+
+    model = config["models"]["assess"]
+    effort = config["effort"]["assess"]
+    ceiling = config["budget"]["assessment_token_ceiling"]
+
+    token_count = client.count_tokens(model, ASSESS_PROMPT, corpus)
+    log.info("assessment corpus is %d tokens", token_count)
+
+    if should_chunk(token_count, ceiling):
+        log.warning("corpus exceeds %d tokens; assessing per repo instead", ceiling)
+        raw_items: list[dict] = []
+        for harvest in harvests:
+            if not harvest.dependabot_prs:
+                continue
+            chunk = build_corpus([harvest])
+            payload, _ = client.complete(
+                phase="assess",
+                model=model,
+                system=ASSESS_PROMPT,
+                prompt=chunk,
+                effort=effort,
+                max_tokens=8000,
+                cache_system=True,
+                schema=SCHEMA,
+            )
+            raw_items.extend(payload.get("assessments", []))
+    else:
+        payload, _ = client.complete(
+            phase="assess",
+            model=model,
+            system=ASSESS_PROMPT,
+            prompt=corpus,
+            effort=effort,
+            max_tokens=16000,
+            cache_system=True,
+            schema=SCHEMA,
+        )
+        raw_items = payload.get("assessments", [])
+
+    out: dict[str, Assessment] = {}
+    for raw in raw_items:
+        try:
+            item = _to_assessment(raw)
+        except (KeyError, ValueError) as exc:
+            raise ModelResponseInvalid(f"malformed assessment entry {raw!r}: {exc}") from exc
+        out[item.slug] = item
+
+    for harvest in harvests:
+        for pr in harvest.dependabot_prs:
+            if pr.slug not in out:
+                log.warning("no assessment returned for %s; defaulting to MEDIUM", pr.slug)
+                out[pr.slug] = Assessment(
+                    repo=pr.repo,
+                    number=pr.number,
+                    tier=RiskTier.MEDIUM,
+                    merge_order=0,
+                    rationale="No assessment was returned for this PR, so it was left for review.",
+                    deciding_question="NONE",
+                )
+    return out
+
+
+def adversarial_review(
+    pr: PullRequest, assessment: Assessment, client: Client, config: dict
+) -> tuple[bool, str]:
+    """Second opinion on a LOW rating. Returns ``(still_low, objection)``.
+
+    Deliberately runs on a different, weaker model than the assessor so it is not
+    simply the same reasoning agreeing with itself. A concrete objection downgrades
+    the PR to MEDIUM; the executor then comments instead of merging.
+    """
+    prompt = "\n".join(
+        [
+            f"Repository: {pr.repo}  PR #{pr.number}",
+            f"Title: {pr.title}",
+            f"Ecosystem: {pr.ecosystem}   Grouped: {'yes' if pr.is_group else 'no'}",
+            f"Changed files: {', '.join(pr.paths)}",
+            f"Packages moved: {', '.join(assessment.packages) or 'unknown'}",
+            f"Reviewer's rationale: {assessment.rationale}",
+            "",
+            "Release notes (truncated):",
+            pr.body[:BODY_CHARS] or "(none supplied)",
+        ]
+    )
+    verdict, _ = client.complete(
+        phase="adversary",
+        model=config["models"]["adversary"],
+        system=ADVERSARY_PROMPT,
+        prompt=prompt,
+        effort=config["effort"]["adversary"],
+        max_tokens=500,
+    )
+    text = str(verdict).strip()
+    if text.upper().startswith("UNSAFE"):
+        objection = text.split(":", 1)[1].strip() if ":" in text else text
+        log.info("adversary downgraded %s: %s", pr.slug, objection)
+        return False, objection
+    return True, ""

--- a/dependabot-triage/budget.py
+++ b/dependabot-triage/budget.py
@@ -118,9 +118,7 @@ class Budget:
         spend = price(model, usage)
         self.total = self.total + spend
         self.by_phase[phase] = self.by_phase.get(phase, Spend()) + spend
-        log.debug(
-            "%s on %s cost $%.5f (run total $%.4f)", phase, model, spend.usd, self.run_usd
-        )
+        log.debug("%s on %s cost $%.5f (run total $%.4f)", phase, model, spend.usd, self.run_usd)
         return spend
 
     def summary(self) -> dict:

--- a/dependabot-triage/budget.py
+++ b/dependabot-triage/budget.py
@@ -1,0 +1,146 @@
+"""Spend accounting and hard ceilings for model usage.
+
+Cost is computed from the ``usage`` block each response actually returns, never
+estimated from prompt length, so the ledger figure matches the invoice. Two
+ceilings apply: one per run and one per calendar month, the latter read back from
+the metrics history. Hitting either aborts the run — merges stop, the email goes
+out flagged red, and nothing is left half-finished.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+# USD per million tokens: (input, output). Cache reads bill at ~0.1x input and
+# cache writes at ~1.25x input.
+PRICING: dict[str, tuple[float, float]] = {
+    "claude-opus-5": (5.00, 25.00),
+    "claude-sonnet-5": (3.00, 15.00),
+    "claude-haiku-4-5": (1.00, 5.00),
+}
+CACHE_READ_MULTIPLIER = 0.10
+CACHE_WRITE_MULTIPLIER = 1.25
+
+
+class BudgetExceeded(RuntimeError):
+    """A spend ceiling was reached. The run stops; nothing further is merged."""
+
+
+@dataclass
+class Spend:
+    """Running total for one phase or one whole run."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    usd: float = 0.0
+    calls: int = 0
+
+    def __add__(self, other: Spend) -> Spend:
+        return Spend(
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            cache_read_tokens=self.cache_read_tokens + other.cache_read_tokens,
+            cache_write_tokens=self.cache_write_tokens + other.cache_write_tokens,
+            usd=self.usd + other.usd,
+            calls=self.calls + other.calls,
+        )
+
+
+def price(model: str, usage: dict) -> Spend:
+    """Convert one response's ``usage`` block into a costed :class:`Spend`.
+
+    An unknown model is priced at the most expensive published rate rather than
+    zero, so a model-id typo shows up as an alarming number instead of silently
+    disabling the ceiling.
+    """
+    if model not in PRICING:
+        log.warning("no published price for %r; charging at the highest known rate", model)
+    in_rate, out_rate = PRICING.get(model, max(PRICING.values()))
+
+    input_tokens = int(usage.get("input_tokens", 0))
+    output_tokens = int(usage.get("output_tokens", 0))
+    cache_read = int(usage.get("cache_read_input_tokens", 0))
+    cache_write = int(usage.get("cache_creation_input_tokens", 0))
+
+    usd = (
+        input_tokens * in_rate
+        + cache_read * in_rate * CACHE_READ_MULTIPLIER
+        + cache_write * in_rate * CACHE_WRITE_MULTIPLIER
+        + output_tokens * out_rate
+    ) / 1_000_000
+
+    return Spend(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read,
+        cache_write_tokens=cache_write,
+        usd=usd,
+        calls=1,
+    )
+
+
+@dataclass
+class Budget:
+    """Enforces the per-run and per-month ceilings."""
+
+    max_per_run: float = 1.00
+    max_per_month: float = 20.00
+    month_to_date: float = 0.0
+    total: Spend = field(default_factory=Spend)
+    by_phase: dict[str, Spend] = field(default_factory=dict)
+
+    @property
+    def run_usd(self) -> float:
+        return self.total.usd
+
+    @property
+    def month_usd(self) -> float:
+        return self.month_to_date + self.total.usd
+
+    def check_before_call(self) -> None:
+        """Refuse to start another call when a ceiling is already reached."""
+        if self.run_usd >= self.max_per_run:
+            raise BudgetExceeded(
+                f"per-run ceiling reached: ${self.run_usd:.4f} >= ${self.max_per_run:.2f}"
+            )
+        if self.month_usd >= self.max_per_month:
+            raise BudgetExceeded(
+                f"monthly ceiling reached: ${self.month_usd:.2f} >= ${self.max_per_month:.2f}"
+            )
+
+    def record(self, phase: str, model: str, usage: dict) -> Spend:
+        """Charge one response against the budget and return its cost."""
+        spend = price(model, usage)
+        self.total = self.total + spend
+        self.by_phase[phase] = self.by_phase.get(phase, Spend()) + spend
+        log.debug(
+            "%s on %s cost $%.5f (run total $%.4f)", phase, model, spend.usd, self.run_usd
+        )
+        return spend
+
+    def summary(self) -> dict:
+        """Serialisable snapshot for the ledger and the email."""
+        return {
+            "run_usd": round(self.run_usd, 4),
+            "month_usd": round(self.month_usd, 4),
+            "max_per_run": self.max_per_run,
+            "max_per_month": self.max_per_month,
+            "calls": self.total.calls,
+            "input_tokens": self.total.input_tokens,
+            "output_tokens": self.total.output_tokens,
+            "cache_read_tokens": self.total.cache_read_tokens,
+            "by_phase": {
+                phase: {"usd": round(s.usd, 5), "calls": s.calls}
+                for phase, s in sorted(self.by_phase.items())
+            },
+        }
+
+
+def should_chunk(token_count: int, ceiling: int) -> bool:
+    """True when the assessment corpus is too large to send as one request."""
+    return token_count > ceiling

--- a/dependabot-triage/config.yml
+++ b/dependabot-triage/config.yml
@@ -1,0 +1,78 @@
+# Dependabot triage agent — runtime configuration.
+#
+# Every limit here is a safety valve. Raising one widens the blast radius of a
+# misclassification, so change them one at a time and watch the precision metric
+# in the nightly email before going further.
+
+owner: wcmchenry3-stack
+
+# Repos are opted in individually. `enabled: false` is the per-repo kill switch;
+# it is honoured before any API call is made against that repo.
+repos:
+  - name: powerplayshistory_site
+    enabled: true
+    base: dev
+    merge_method: merge # ruleset on this repo forbids squash
+  - name: buffingchi_site
+    enabled: false
+    base: dev
+    merge_method: merge
+  - name: BC-Arcade
+    enabled: false
+    base: dev
+    merge_method: squash
+  - name: BookshelfAI
+    enabled: false
+    base: dev
+    merge_method: merge
+  - name: wcm_portfolio_site
+    enabled: false
+    base: dev
+    merge_method: merge
+  - name: RulersAI
+    enabled: false
+    base: dev
+    merge_method: merge
+
+# Blast-radius caps. A bad classification cannot cascade across the stack
+# before the morning email lands.
+caps:
+  max_merges_per_repo: 5
+  max_merges_total: 15
+
+# Wall-clock budgets, in seconds.
+timeouts:
+  rebase_wait: 1200 # 20 min for Dependabot to land a rebase, then defer
+  checks_wait: 2700 # 45 min, sized for BC-Arcade's 20-30 min CI
+  poll_interval: 60
+  global_wall_clock: 14400 # 4 h; job timeout-minutes is set slightly above this
+
+# Spend ceilings in USD, enforced in code against real `usage` blocks.
+budget:
+  max_per_run: 1.00
+  max_per_month: 20.00
+  # Corpus larger than this is split per-repo rather than sent as one request.
+  assessment_token_ceiling: 150000
+
+models:
+  assess: claude-sonnet-5
+  adversary: claude-haiku-4-5
+  diagnose: claude-haiku-4-5
+  delta: claude-haiku-4-5
+  summary: claude-haiku-4-5
+  escalate: claude-opus-5 # workflow_dispatch only, never the nightly path
+
+effort:
+  assess: medium
+  adversary: low
+  diagnose: low
+  delta: low
+  summary: low
+
+# Per-PR kill switch.
+hold_label: "dependabot-triage:hold"
+
+report:
+  from_address: "dependabot-triage@mail.buffingchi.com"
+  to_address: "wcmchenry3@gmail.com"
+  subject_prefix: "Dependabot Triage"

--- a/dependabot-triage/diagnose.py
+++ b/dependabot-triage/diagnose.py
@@ -1,0 +1,117 @@
+"""Phase 4 — explain a failing check. Produces a comment, never an action.
+
+Runs on the cheap model by default and escalates once when that model reports low
+confidence in its own answer. The output is prose destined for a PR comment; no
+part of the system reads it back as an instruction.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import gh
+from llm import Client
+from models import PullRequest
+
+log = logging.getLogger(__name__)
+
+DIAGNOSE_PROMPT = (Path(__file__).parent / "prompts" / "diagnose.md").read_text(encoding="utf-8")
+
+CONFIDENCE_RE = re.compile(r"CONFIDENCE:\s*(HIGH|MEDIUM|LOW)", re.IGNORECASE)
+LOG_TAIL_LINES = 120
+
+
+def _failed_check_names(pr: PullRequest, required: frozenset[str]) -> list[str]:
+    return [c.name for c in pr.failing_required(required)]
+
+
+def _fetch_log_tail(repo: str, owner: str, number: int) -> str:
+    """Last lines of the failing job's log.
+
+    Best-effort: the log endpoint is noisy and occasionally unavailable, and a
+    missing log is a normal outcome rather than a reason to fail the run.
+    """
+    try:
+        raw = gh._run(
+            ["run", "list", "--repo", f"{owner}/{repo}", "--limit", "1", "--json", "databaseId"]
+        )
+    except gh.GhError as exc:
+        log.info("could not list runs for %s#%s: %s", repo, number, exc)
+        return ""
+    import json
+
+    runs = json.loads(raw) if raw.strip() else []
+    if not runs:
+        return ""
+    try:
+        logs = gh._run(
+            [
+                "run",
+                "view",
+                str(runs[0]["databaseId"]),
+                "--repo",
+                f"{owner}/{repo}",
+                "--log-failed",
+            ],
+            timeout=180,
+        )
+    except gh.GhError as exc:
+        log.info("could not read failed log for %s#%s: %s", repo, number, exc)
+        return ""
+    return "\n".join(logs.splitlines()[-LOG_TAIL_LINES:])
+
+
+def diagnose(
+    pr: PullRequest,
+    required: frozenset[str],
+    client: Client,
+    config: dict,
+    *,
+    dry_run: bool = True,
+) -> str:
+    """Return a short diagnosis of the PR's failing checks."""
+    failing = _failed_check_names(pr, required)
+    if not failing:
+        return ""
+
+    log_tail = "" if dry_run else _fetch_log_tail(pr.repo, config["owner"], pr.number)
+
+    prompt = "\n".join(
+        [
+            f"Repository: {pr.repo}  PR #{pr.number}",
+            f"Title: {pr.title}",
+            f"Ecosystem: {pr.ecosystem}",
+            f"Changed files: {', '.join(pr.paths)}",
+            f"Failing required checks: {', '.join(failing)}",
+            "",
+            "Failing job log (tail):",
+            log_tail or "(no log available)",
+        ]
+    )
+
+    text, _ = client.complete(
+        phase="diagnose",
+        model=config["models"]["diagnose"],
+        system=DIAGNOSE_PROMPT,
+        prompt=prompt,
+        effort=config["effort"]["diagnose"],
+        max_tokens=1200,
+    )
+
+    match = CONFIDENCE_RE.search(str(text))
+    confidence = match.group(1).upper() if match else "LOW"
+
+    if confidence == "LOW" and config["models"]["diagnose"] != config["models"]["assess"]:
+        log.info("escalating diagnosis of %s to %s", pr.slug, config["models"]["assess"])
+        text, _ = client.complete(
+            phase="diagnose-escalated",
+            model=config["models"]["assess"],
+            system=DIAGNOSE_PROMPT,
+            prompt=prompt,
+            effort="medium",
+            max_tokens=1200,
+        )
+
+    return CONFIDENCE_RE.sub("", str(text)).strip()

--- a/dependabot-triage/execute.py
+++ b/dependabot-triage/execute.py
@@ -1,0 +1,367 @@
+"""Phase 3 — act on the assessment. Deterministic; no model decides anything here.
+
+The loop deliberately does not wait on rebases one at a time. Dependabot lands a
+rebase asynchronously — usually in a couple of minutes, sometimes far longer for a
+large lockfile — so every rebase is requested up front and PRs are then drained in
+whatever order they become ready. Nothing is force-merged to beat the clock; work
+that does not finish is deferred to tomorrow, which costs nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+
+import gh
+import guards
+from assess import adversarial_review
+from harvest import RepoHarvest
+from llm import Client
+from models import Action, Assessment, Decision, PullRequest, RiskTier
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class Pending:
+    """A PR waiting on Dependabot to land a rebase."""
+
+    pr: PullRequest
+    harvest: RepoHarvest
+    assessment: Assessment
+    original_sha: str
+    requested_at: float
+    recreated: bool = False
+
+
+@dataclass
+class ExecutionResult:
+    decisions: list[Decision] = field(default_factory=list)
+    merges_by_repo: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def total_merges(self) -> int:
+        return sum(self.merges_by_repo.values())
+
+
+def _comment_body(decision: Decision, run_url: str) -> str:
+    """The PR comment. Says what was decided and, when refused, exactly why."""
+    if decision.action is Action.MERGE:
+        head = "### Merged automatically by nightly Dependabot triage"
+        detail = decision.reason
+    else:
+        head = "### Left for review by nightly Dependabot triage"
+        detail = decision.reason
+
+    lines = [head, "", detail, ""]
+
+    failed = [g for g in decision.guard_results if not g.passed]
+    if failed:
+        lines.append("**Failed preconditions:**")
+        lines += [f"- `{g.guard_id}` — {g.detail}" for g in failed]
+        lines.append("")
+    if decision.diagnosis:
+        lines += ["**CI failure analysis:**", "", decision.diagnosis, ""]
+    if decision.deciding_question and decision.deciding_question != "NONE":
+        lines.append(f"Deciding rubric question: `{decision.deciding_question}`")
+
+    lines += [
+        "",
+        f"Risk tier: `{decision.tier.value}` · [run log]({run_url})",
+        "",
+        "_This comment is generated. No file in this PR was modified by the agent — "
+        "it may only comment, ask Dependabot to rebase, and merge._",
+    ]
+    return "\n".join(lines)
+
+
+def _refresh(pr: PullRequest, harvest: RepoHarvest, owner: str) -> PullRequest:
+    """Re-read a PR from the API so guards run against current state."""
+    from harvest import harvest_repo
+
+    fresh = harvest_repo(harvest.repo, owner, harvest.base, harvest.merge_method, fetch_diffs=True)
+    for candidate in fresh.dependabot_prs:
+        if candidate.number == pr.number:
+            return candidate
+    return pr
+
+
+def _checks_settled(pr: PullRequest, required: frozenset[str]) -> bool:
+    """True once every required check has reached a terminal state."""
+    by_name = {c.name: c for c in pr.checks}
+    return all(name in by_name and by_name[name].is_settled for name in required)
+
+
+def _packages_drifted(assessment: Assessment, pr: PullRequest) -> bool:
+    """Did a rebase change what this PR actually moves?
+
+    A rebase can pull in different transitive versions than the ones assessed, so
+    a stale LOW is never trusted — the caller re-confirms the tier when this is true.
+    """
+    if not assessment.packages:
+        return False
+    from harvest import parse_bump
+
+    package, _, to_version = parse_bump(pr.title)
+    if not package:
+        return False
+    return not any(package in entry and to_version in entry for entry in assessment.packages)
+
+
+def execute(
+    harvests: list[RepoHarvest],
+    assessments: dict[str, Assessment],
+    client: Client,
+    config: dict,
+    *,
+    run_url: str = "",
+    dry_run: bool = True,
+) -> ExecutionResult:
+    """Run the full decision loop across every repo."""
+    owner = config["owner"]
+    caps = config["caps"]
+    timeouts = config["timeouts"]
+    hold_label = config["hold_label"]
+
+    result = ExecutionResult()
+    pending: list[Pending] = []
+    started = time.monotonic()
+
+    def budget_left() -> float:
+        return timeouts["global_wall_clock"] - (time.monotonic() - started)
+
+    # ---- Pass 1: decide, and fan out every rebase request without waiting -----
+    for harvest in harvests:
+        ordered = sorted(
+            harvest.dependabot_prs,
+            key=lambda p: assessments.get(
+                p.slug, Assessment(p.repo, p.number, RiskTier.MEDIUM, 0, "")
+            ).merge_order,
+        )
+        for pr in ordered:
+            assessment = assessments.get(pr.slug)
+            if assessment is None:
+                continue
+
+            if assessment.tier is not RiskTier.LOW:
+                result.decisions.append(
+                    Decision(
+                        repo=pr.repo,
+                        number=pr.number,
+                        title=pr.title,
+                        tier=assessment.tier,
+                        action=Action.COMMENT,
+                        reason=assessment.rationale,
+                        deciding_question=assessment.deciding_question,
+                    )
+                )
+                continue
+
+            checks = guards.run_all_guards(
+                pr, harvest.baseline, assessed_sha=pr.head_sha, hold_label=hold_label
+            )
+            failed = guards.failures(checks)
+            blocking = [g for g in failed if g.guard_id != "G10"]
+
+            if blocking:
+                result.decisions.append(
+                    Decision(
+                        repo=pr.repo,
+                        number=pr.number,
+                        title=pr.title,
+                        tier=assessment.tier,
+                        action=Action.SKIP,
+                        reason="Automated merge refused by a precondition check.",
+                        guard_results=checks,
+                        deciding_question=assessment.deciding_question,
+                    )
+                )
+                continue
+
+            still_low, objection = adversarial_review(pr, assessment, client, config)
+            if not still_low:
+                result.decisions.append(
+                    Decision(
+                        repo=pr.repo,
+                        number=pr.number,
+                        title=pr.title,
+                        tier=RiskTier.MEDIUM,
+                        action=Action.COMMENT,
+                        reason=f"Downgraded on adversarial review: {objection}",
+                        deciding_question=assessment.deciding_question,
+                    )
+                )
+                continue
+
+            if pr.merge_state_status.upper() == "BEHIND" or any(
+                g.guard_id == "G10" for g in failed
+            ):
+                gh.request_rebase(pr.repo, owner, pr.number, dry_run=dry_run)
+                pending.append(Pending(pr, harvest, assessment, pr.head_sha, time.monotonic()))
+                continue
+
+            pending.append(Pending(pr, harvest, assessment, "", time.monotonic()))
+
+    # ---- Pass 2: drain, first-ready-first-served -----------------------------
+    while pending and budget_left() > 0:
+        progressed = False
+
+        for item in list(pending):
+            if result.total_merges >= caps["max_merges_total"]:
+                break
+            if result.merges_by_repo.get(item.harvest.repo, 0) >= caps["max_merges_per_repo"]:
+                pending.remove(item)
+                result.decisions.append(
+                    Decision(
+                        repo=item.pr.repo,
+                        number=item.pr.number,
+                        title=item.pr.title,
+                        tier=item.assessment.tier,
+                        action=Action.SKIP,
+                        reason=f"Per-repo merge cap of {caps['max_merges_per_repo']} reached.",
+                        deferred=True,
+                    )
+                )
+                continue
+
+            waited = time.monotonic() - item.requested_at
+            fresh = item.pr if dry_run else _refresh(item.pr, item.harvest, owner)
+
+            if item.original_sha and fresh.head_sha == item.original_sha:
+                if waited > timeouts["rebase_wait"]:
+                    if not item.recreated:
+                        gh.request_rebase(
+                            fresh.repo, owner, fresh.number, recreate=True, dry_run=dry_run
+                        )
+                        item.recreated = True
+                        item.requested_at = time.monotonic()
+                        progressed = True
+                        continue
+                    pending.remove(item)
+                    result.decisions.append(
+                        Decision(
+                            repo=fresh.repo,
+                            number=fresh.number,
+                            title=fresh.title,
+                            tier=item.assessment.tier,
+                            action=Action.COMMENT,
+                            reason="Dependabot did not land a rebase in time; deferred to the next run.",
+                            deferred=True,
+                            rebased=True,
+                        )
+                    )
+                    progressed = True
+                continue
+
+            required = item.harvest.baseline.required_contexts
+            if not _checks_settled(fresh, required):
+                if waited > timeouts["checks_wait"]:
+                    pending.remove(item)
+                    result.decisions.append(
+                        Decision(
+                            repo=fresh.repo,
+                            number=fresh.number,
+                            title=fresh.title,
+                            tier=item.assessment.tier,
+                            action=Action.COMMENT,
+                            reason="CI had not finished within the wait budget; deferred to the next run.",
+                            deferred=True,
+                        )
+                    )
+                    progressed = True
+                continue
+
+            pending.remove(item)
+            progressed = True
+
+            if item.original_sha and _packages_drifted(item.assessment, fresh):
+                result.decisions.append(
+                    Decision(
+                        repo=fresh.repo,
+                        number=fresh.number,
+                        title=fresh.title,
+                        tier=RiskTier.MEDIUM,
+                        action=Action.COMMENT,
+                        reason=(
+                            "The rebase changed which package versions this PR moves, so the "
+                            "original low-risk assessment no longer applies. Left for review."
+                        ),
+                        rebased=True,
+                    )
+                )
+                continue
+
+            live_contexts = (
+                item.harvest.baseline.required_contexts
+                if dry_run
+                else gh.required_contexts(fresh.repo, owner, item.harvest.base)
+            )
+            checks = guards.run_all_guards(
+                fresh,
+                item.harvest.baseline,
+                assessed_sha=fresh.head_sha,
+                live_contexts=live_contexts,
+                hold_label=hold_label,
+            )
+
+            if not guards.may_merge(checks):
+                result.decisions.append(
+                    Decision(
+                        repo=fresh.repo,
+                        number=fresh.number,
+                        title=fresh.title,
+                        tier=item.assessment.tier,
+                        action=Action.SKIP,
+                        reason="Preconditions no longer held at merge time.",
+                        guard_results=checks,
+                        rebased=bool(item.original_sha),
+                    )
+                )
+                continue
+
+            gh.merge(fresh.repo, owner, fresh.number, item.harvest.merge_method, dry_run=dry_run)
+            result.merges_by_repo[fresh.repo] = result.merges_by_repo.get(fresh.repo, 0) + 1
+            result.decisions.append(
+                Decision(
+                    repo=fresh.repo,
+                    number=fresh.number,
+                    title=fresh.title,
+                    tier=RiskTier.LOW,
+                    action=Action.MERGE,
+                    reason=item.assessment.rationale,
+                    guard_results=checks,
+                    rebased=bool(item.original_sha),
+                    merged=True,
+                )
+            )
+
+        if pending and not progressed:
+            if dry_run:
+                break
+            time.sleep(timeouts["poll_interval"])
+
+    for item in pending:
+        result.decisions.append(
+            Decision(
+                repo=item.pr.repo,
+                number=item.pr.number,
+                title=item.pr.title,
+                tier=item.assessment.tier,
+                action=Action.COMMENT,
+                reason="Run reached its wall-clock budget; deferred to the next run.",
+                deferred=True,
+            )
+        )
+
+    for decision in result.decisions:
+        if decision.action in (Action.COMMENT, Action.SKIP) or decision.merged:
+            gh.comment(
+                decision.repo,
+                owner,
+                decision.number,
+                _comment_body(decision, run_url),
+                dry_run=dry_run,
+            )
+
+    return result

--- a/dependabot-triage/gh.py
+++ b/dependabot-triage/gh.py
@@ -1,0 +1,228 @@
+"""Thin, auditable wrapper around the ``gh`` CLI.
+
+Every GitHub interaction the agent performs goes through one of these functions,
+which keeps the complete list of side effects short enough to read in one sitting:
+:func:`comment`, :func:`request_rebase`, and :func:`merge`. There is deliberately
+no generic "run this command" escape hatch.
+
+Subprocess calls always pass an argument list — never ``shell=True`` — so nothing
+in a PR title or package name can reach a shell.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+class GhError(RuntimeError):
+    """A ``gh`` invocation failed."""
+
+
+def _run(args: list[str], *, timeout: int = 120) -> str:
+    """Execute ``gh`` with an argument list and return stdout."""
+    log.debug("gh %s", " ".join(args))
+    try:
+        proc = subprocess.run(  # noqa: S603 - argument list, never shell=True
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment issue
+        raise GhError("the `gh` CLI is not installed or not on PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise GhError(f"gh {args[0]} timed out after {timeout}s") from exc
+    if proc.returncode != 0:
+        raise GhError(f"gh {' '.join(args)} failed ({proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def api(path: str, *, method: str = "GET", fields: dict[str, str] | None = None) -> Any:
+    """Call the REST API and parse the JSON response."""
+    args = ["api", "--method", method, path]
+    for key, value in (fields or {}).items():
+        args += ["-f", f"{key}={value}"]
+    raw = _run(args)
+    return json.loads(raw) if raw.strip() else None
+
+
+def graphql(query: str, **variables: str) -> Any:
+    """Call the GraphQL API. Used where REST would need several round trips."""
+    args = ["api", "graphql", "-f", f"query={query}"]
+    for key, value in variables.items():
+        args += ["-f", f"{key}={value}"]
+    return json.loads(_run(args))
+
+
+def list_open_prs(repo: str, owner: str) -> list[dict[str, Any]]:
+    """Open PRs with the fields the triage needs, in one call per repo."""
+    raw = _run(
+        [
+            "pr",
+            "list",
+            "--repo",
+            f"{owner}/{repo}",
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,author,baseRefName,headRefOid,labels,files,"
+            "mergeable,mergeStateStatus,body,createdAt",
+        ]
+    )
+    return json.loads(raw) if raw.strip() else []
+
+
+def pr_diff(repo: str, owner: str, number: int) -> str:
+    """Unified diff for a PR. Needed because `pr list --json files` omits patches."""
+    return _run(["pr", "diff", str(number), "--repo", f"{owner}/{repo}"], timeout=180)
+
+
+def pr_checks(repo: str, owner: str, number: int) -> list[dict[str, Any]]:
+    """Check-run states for the PR head.
+
+    ``gh pr checks`` exits non-zero when any check is failing, which is a normal
+    outcome here rather than an error, so the raw result is tolerated.
+    """
+    try:
+        raw = _run(
+            [
+                "pr",
+                "checks",
+                str(number),
+                "--repo",
+                f"{owner}/{repo}",
+                "--json",
+                "name,state,bucket",
+            ]
+        )
+    except GhError as exc:
+        # Non-zero exit with a parseable body means "some check is red".
+        text = str(exc)
+        start = text.find("[")
+        if start == -1:
+            log.warning("no check data for %s/%s#%s: %s", owner, repo, number, exc)
+            return []
+        raw = text[start : text.rfind("]") + 1]
+    return json.loads(raw) if raw.strip() else []
+
+
+def required_contexts(repo: str, owner: str, branch: str) -> frozenset[str]:
+    """Required status checks for a branch, from classic protection or rulesets.
+
+    Repos in this org use both mechanisms, and a repo may have neither — in which
+    case the empty set is returned and guard G06 refuses to auto-merge there.
+    """
+    contexts: set[str] = set()
+    try:
+        protection = api(f"repos/{owner}/{repo}/branches/{branch}/protection")
+        checks = (protection or {}).get("required_status_checks") or {}
+        contexts.update(checks.get("contexts") or [])
+        for entry in checks.get("checks") or []:
+            if entry.get("context"):
+                contexts.add(entry["context"])
+    except GhError:
+        log.info("%s/%s has no classic branch protection on %s", owner, repo, branch)
+
+    try:
+        for ruleset in api(f"repos/{owner}/{repo}/rulesets") or []:
+            detail = api(f"repos/{owner}/{repo}/rulesets/{ruleset['id']}")
+            include = ((detail.get("conditions") or {}).get("ref_name") or {}).get("include", [])
+            if f"refs/heads/{branch}" not in include and "~ALL" not in include:
+                continue
+            for rule in detail.get("rules") or []:
+                if rule.get("type") != "required_status_checks":
+                    continue
+                params = rule.get("parameters") or {}
+                for entry in params.get("required_status_checks") or []:
+                    if entry.get("context"):
+                        contexts.add(entry["context"])
+    except GhError:
+        log.info("%s/%s exposes no rulesets", owner, repo)
+
+    return frozenset(contexts)
+
+
+def file_shas(repo: str, owner: str, directory: str, ref: str) -> dict[str, str]:
+    """Blob SHA per file in a directory — the tamper baseline for workflows."""
+    try:
+        entries = api(f"repos/{owner}/{repo}/contents/{directory}?ref={ref}") or []
+    except GhError:
+        return {}
+    return {e["path"]: e["sha"] for e in entries if e.get("type") == "file"}
+
+
+def file_text(repo: str, owner: str, path: str, ref: str) -> str:
+    """Decoded file contents, or an empty string when the file is absent."""
+    import base64
+
+    try:
+        entry = api(f"repos/{owner}/{repo}/contents/{path}?ref={ref}")
+    except GhError:
+        return ""
+    if not entry or entry.get("encoding") != "base64":
+        return ""
+    return base64.b64decode(entry["content"]).decode("utf-8", errors="replace")
+
+
+# --------------------------------------------------------------------------
+# The three mutating operations. Nothing else in this package writes to GitHub.
+# --------------------------------------------------------------------------
+
+
+def comment(repo: str, owner: str, number: int, body: str, *, dry_run: bool = False) -> None:
+    """Post a PR comment."""
+    if dry_run:
+        log.info("[dry-run] would comment on %s/%s#%s", owner, repo, number)
+        return
+    _run(["pr", "comment", str(number), "--repo", f"{owner}/{repo}", "--body", body])
+
+
+def request_rebase(
+    repo: str, owner: str, number: int, *, recreate: bool = False, dry_run: bool = False
+) -> None:
+    """Ask Dependabot to rebase or recreate the branch.
+
+    The agent never rebases a branch itself; it asks Dependabot to, and Dependabot
+    force-pushes under its own identity. That is why the agent's token needs no
+    ability to write to a target repo's git tree at all.
+    """
+    body = "@dependabot recreate" if recreate else "@dependabot rebase"
+    if dry_run:
+        log.info("[dry-run] would post %r on %s/%s#%s", body, owner, repo, number)
+        return
+    comment(repo, owner, number, body)
+
+
+def merge(
+    repo: str, owner: str, number: int, method: str = "squash", *, dry_run: bool = False
+) -> None:
+    """Merge the PR.
+
+    ``--admin`` is never passed: administrator bypass of branch protection is
+    exactly the shortcut this agent must not be able to take.
+    """
+    if method not in ("squash", "merge", "rebase"):
+        raise ValueError(f"unsupported merge method {method!r}")
+    if dry_run:
+        log.info("[dry-run] would %s-merge %s/%s#%s", method, owner, repo, number)
+        return
+    _run(
+        [
+            "pr",
+            "merge",
+            str(number),
+            "--repo",
+            f"{owner}/{repo}",
+            f"--{method}",
+            "--delete-branch",
+        ],
+        timeout=180,
+    )

--- a/dependabot-triage/guards.py
+++ b/dependabot-triage/guards.py
@@ -395,13 +395,18 @@ def extract_thresholds(text: str) -> dict[str, float]:
 
 
 def workflow_pin_changes(files: list[ChangedFile]) -> list[str]:
-    """Human-readable summary of the ``uses:`` pins a PR moves."""
-    out: list[str] = []
+    """Human-readable summary of the ``uses:`` pins a PR moves.
+
+    Deduplicated in first-seen order: an action pinned in several jobs of the same
+    workflow produces one diff line each, and listing the same bump four times in
+    a PR comment reads as a bug rather than as thoroughness.
+    """
+    seen: dict[str, None] = {}
     for f in files:
         if not _is_workflow(f.path):
             continue
         for line in f.added_lines():
             match = re.search(r"uses:\s*(\S+)@(\S+)", line)
             if match:
-                out.append(f"{match.group(1)}@{match.group(2)}")
-    return out
+                seen.setdefault(f"{match.group(1)}@{match.group(2)}")
+    return list(seen)

--- a/dependabot-triage/guards.py
+++ b/dependabot-triage/guards.py
@@ -194,9 +194,7 @@ def guard_no_denylisted_paths(pr: PullRequest) -> GuardResult:
     """G03 — no CI-defining file is touched, whatever the allowlist says."""
     hits = [p for p in pr.paths if _matches_any(p, PATH_DENYLIST)]
     if hits:
-        return GuardResult(
-            "G03", False, f"touches CI-defining files: {', '.join(sorted(hits))}"
-        )
+        return GuardResult("G03", False, f"touches CI-defining files: {', '.join(sorted(hits))}")
     return GuardResult("G03", True, "no CI-defining files touched")
 
 
@@ -268,9 +266,7 @@ def guard_required_checks_green(pr: PullRequest, baseline: RepoBaseline) -> Guar
     if failing:
         names = ", ".join(f"{c.name}={c.conclusion or c.status}" for c in failing)
         return GuardResult("G06", False, f"required checks not green: {names}")
-    return GuardResult(
-        "G06", True, f"all {len(baseline.required_contexts)} required checks green"
-    )
+    return GuardResult("G06", True, f"all {len(baseline.required_contexts)} required checks green")
 
 
 def guard_protection_unchanged(
@@ -295,15 +291,15 @@ def guard_head_sha_unchanged(pr: PullRequest, assessed_sha: str) -> GuardResult:
     return GuardResult(
         "G08",
         ok,
-        "head SHA matches assessment"
-        if ok
-        else f"head moved {assessed_sha[:7]} -> {pr.head_sha[:7]} since assessment",
+        (
+            "head SHA matches assessment"
+            if ok
+            else f"head moved {assessed_sha[:7]} -> {pr.head_sha[:7]} since assessment"
+        ),
     )
 
 
-def guard_thresholds_not_lowered(
-    baseline: RepoBaseline, current: dict[str, float]
-) -> GuardResult:
+def guard_thresholds_not_lowered(baseline: RepoBaseline, current: dict[str, float]) -> GuardResult:
     """G09 — numeric quality gates may rise or hold, never fall."""
     lowered = [
         f"{k}: {baseline.thresholds[k]} -> {v}"

--- a/dependabot-triage/guards.py
+++ b/dependabot-triage/guards.py
@@ -1,0 +1,411 @@
+"""Deterministic merge preconditions — the security boundary of the agent.
+
+Nothing in this module calls a model. Every function is pure over its inputs so
+the whole boundary is testable from fixtures. The executor may only merge a pull
+request when :func:`run_all_guards` returns no failures, and it re-runs the full
+set against freshly fetched API state immediately before the merge call.
+
+Guard IDs are stable and appear verbatim in the ledger, the PR comment, and the
+nightly email, so a failure can always be traced back to the rule that caused it.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+
+from models import ChangedFile, GuardResult, PullRequest, RepoBaseline
+
+DEPENDABOT_AUTHORS = frozenset({"app/dependabot", "dependabot[bot]", "dependabot"})
+
+# Paths a Dependabot PR is permitted to touch. Matched with fnmatch against the
+# repo-relative path; `**/` prefixes cover monorepo subdirectories.
+PATH_ALLOWLIST: tuple[str, ...] = (
+    "package.json",
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "bun.lockb",
+    "**/package.json",
+    "**/package-lock.json",
+    "**/npm-shrinkwrap.json",
+    "**/yarn.lock",
+    "**/pnpm-lock.yaml",
+    "**/bun.lockb",
+    "requirements.txt",
+    "requirements-*.txt",
+    "**/requirements.txt",
+    "**/requirements-*.txt",
+    "pyproject.toml",
+    "**/pyproject.toml",
+    "poetry.lock",
+    "**/poetry.lock",
+    "Pipfile",
+    "Pipfile.lock",
+    "**/Pipfile",
+    "**/Pipfile.lock",
+    "Gemfile.lock",
+    "**/Gemfile.lock",
+    "Podfile.lock",
+    "**/Podfile.lock",
+    "go.mod",
+    "go.sum",
+    "**/go.mod",
+    "**/go.sum",
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml",
+)
+
+# Checked before the allowlist and always wins. These are the files that define
+# whether CI is meaningful; a dependency bump has no business editing them.
+PATH_DENYLIST: tuple[str, ...] = (
+    ".gitleaks.toml",
+    "**/.gitleaks.toml",
+    "codecov.yml",
+    ".codecov.yml",
+    "**/codecov.yml",
+    "pytest.ini",
+    "**/pytest.ini",
+    "setup.cfg",
+    "**/setup.cfg",
+    "tox.ini",
+    "**/tox.ini",
+    ".coveragerc",
+    "**/.coveragerc",
+    ".eslintrc*",
+    "**/.eslintrc*",
+    "eslint.config.*",
+    "**/eslint.config.*",
+    "jest.config.*",
+    "**/jest.config.*",
+    "vitest.config.*",
+    "**/vitest.config.*",
+    "playwright.config.*",
+    "**/playwright.config.*",
+    ".pre-commit-config.yaml",
+    "**/.pre-commit-config.yaml",
+    "CODEOWNERS",
+    ".github/CODEOWNERS",
+    "docs/CODEOWNERS",
+    ".github/dependabot.yml",
+    ".github/dependabot.yaml",
+    "renovate.json",
+    ".github/renovate.json",
+)
+
+# A workflow file may change only version pins. Covers bare and SHA-pinned forms,
+# with or without a trailing comment, and with or without a YAML list dash.
+USES_PIN_RE = re.compile(r"^[+-]\s*(?:-\s+)?uses:\s*\S+@\S+\s*(?:#.*)?$")
+
+# Machine-generated files whose contents are package metadata we do not control,
+# so a forbidden token appearing inside one is not evidence of tampering.
+GENERATED_LOCKFILES: tuple[str, ...] = (
+    "*package-lock.json",
+    "*npm-shrinkwrap.json",
+    "*yarn.lock",
+    "*pnpm-lock.yaml",
+    "*bun.lockb",
+    "*poetry.lock",
+    "*Pipfile.lock",
+    "*Gemfile.lock",
+    "*Podfile.lock",
+    "*go.sum",
+)
+
+# Tokens that weaken a check. Scanned against *added* lines only, outside
+# generated lockfiles. Each entry is (regex, human-readable explanation).
+FORBIDDEN_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"continue-on-error\s*:\s*true"), "disables failure propagation in CI"),
+    (re.compile(r"\bif\s*:\s*false\b"), "disables a CI job or step outright"),
+    (re.compile(r"\|\|\s*true\b"), "swallows a non-zero exit code"),
+    (re.compile(r"--no-verify\b"), "bypasses git hooks"),
+    (re.compile(r"--audit-level[= ]"), "changes the vulnerability failure threshold"),
+    (re.compile(r"--cov-fail-under[= ]"), "changes the coverage failure threshold"),
+    (re.compile(r"\bfail_ci_if_error\s*:\s*false"), "stops coverage upload failures failing CI"),
+    (re.compile(r"\b(?:describe|it|test)\.(?:skip|only)\s*\("), "skips or isolates tests"),
+    (re.compile(r"@pytest\.mark\.(?:skip|xfail)"), "skips or expects-fail a test"),
+    (re.compile(r"eslint-disable"), "suppresses a lint rule"),
+    (re.compile(r"#\s*type:\s*ignore"), "suppresses a type error"),
+    (re.compile(r"--legacy-peer-deps\b"), "masks an unresolved peer-dependency conflict"),
+    (re.compile(r"npm\s+(?:install|ci)[^\n]*--force\b"), "forces past dependency resolution"),
+    (re.compile(r"\bSKIP\s*=\s*\S+"), "skips pre-commit hooks"),
+)
+
+# Numeric quality gates. Values may rise or hold, never fall (guard G08).
+THRESHOLD_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("cov_fail_under", re.compile(r"--cov-fail-under[= ](\d+(?:\.\d+)?)")),
+    ("coverage_threshold", re.compile(r"coverage-threshold\s*:\s*(\d+(?:\.\d+)?)")),
+    ("min_coverage", re.compile(r"minimum_coverage\s*:\s*(\d+(?:\.\d+)?)")),
+)
+
+# npm audit levels ordered loosest to strictest; may only tighten.
+AUDIT_LEVELS: tuple[str, ...] = ("info", "low", "moderate", "high", "critical")
+
+
+def _matches_any(path: str, patterns: tuple[str, ...]) -> bool:
+    """True when ``path`` matches any fnmatch pattern.
+
+    ``**/x`` is expanded to also match a bare ``x`` at the repository root so a
+    single pattern covers both layouts.
+    """
+    for pattern in patterns:
+        if fnmatch.fnmatch(path, pattern):
+            return True
+        if pattern.startswith("**/") and fnmatch.fnmatch(path, pattern[3:]):
+            return True
+    return False
+
+
+def _is_generated_lockfile(path: str) -> bool:
+    return _matches_any(path, GENERATED_LOCKFILES)
+
+
+def _is_workflow(path: str) -> bool:
+    return path.startswith(".github/workflows/") and path.endswith((".yml", ".yaml"))
+
+
+# --------------------------------------------------------------------------
+# Individual guards
+# --------------------------------------------------------------------------
+
+
+def guard_author_is_dependabot(pr: PullRequest) -> GuardResult:
+    """G01 — only Dependabot's own PRs are ever in scope."""
+    ok = pr.author in DEPENDABOT_AUTHORS
+    return GuardResult(
+        "G01",
+        ok,
+        "author is Dependabot" if ok else f"author is {pr.author!r}, not Dependabot",
+    )
+
+
+def guard_paths_allowed(pr: PullRequest) -> GuardResult:
+    """G02 — every changed path sits in the manifest/lockfile/workflow allowlist."""
+    stray = [p for p in pr.paths if not _matches_any(p, PATH_ALLOWLIST)]
+    if stray:
+        return GuardResult(
+            "G02", False, f"changed paths outside the allowlist: {', '.join(sorted(stray))}"
+        )
+    return GuardResult("G02", True, f"all {len(pr.paths)} changed paths allowlisted")
+
+
+def guard_no_denylisted_paths(pr: PullRequest) -> GuardResult:
+    """G03 — no CI-defining file is touched, whatever the allowlist says."""
+    hits = [p for p in pr.paths if _matches_any(p, PATH_DENYLIST)]
+    if hits:
+        return GuardResult(
+            "G03", False, f"touches CI-defining files: {', '.join(sorted(hits))}"
+        )
+    return GuardResult("G03", True, "no CI-defining files touched")
+
+
+def guard_workflow_pins_only(pr: PullRequest) -> GuardResult:
+    """G04 — inside ``.github/workflows/``, only ``uses:`` version pins may change.
+
+    This is what makes it safe to let a ``github-actions`` ecosystem PR through
+    at all: the diff is mechanically constrained to version bumps, so it cannot
+    smuggle in a ``continue-on-error`` or delete a job.
+    """
+    offenders: list[str] = []
+    for f in pr.files:
+        if not _is_workflow(f.path):
+            continue
+        if not f.patch:
+            offenders.append(f"{f.path}: no patch available to verify")
+            continue
+        for line in f.changed_lines():
+            if line.strip() in ("+", "-"):
+                continue  # blank-line churn
+            if not USES_PIN_RE.match(line):
+                offenders.append(f"{f.path}: {line.strip()[:80]}")
+    if offenders:
+        return GuardResult(
+            "G04", False, "workflow diff contains non-pin changes: " + "; ".join(offenders[:5])
+        )
+    return GuardResult("G04", True, "workflow changes are version pins only")
+
+
+def guard_no_forbidden_patterns(pr: PullRequest) -> GuardResult:
+    """G05 — no added line weakens a check.
+
+    Scans added lines only, skipping machine-generated lockfiles whose contents
+    are upstream package metadata rather than anything this repo authored.
+    """
+    hits: list[str] = []
+    for f in pr.files:
+        if _is_generated_lockfile(f.path):
+            continue
+        for line in f.added_lines():
+            for pattern, why in FORBIDDEN_PATTERNS:
+                if pattern.search(line):
+                    hits.append(f"{f.path}: {why} ({line.strip()[:60]})")
+                    break
+    if hits:
+        return GuardResult("G05", False, "forbidden changes: " + "; ".join(hits[:5]))
+    return GuardResult("G05", True, "no check-weakening patterns in added lines")
+
+
+def guard_required_checks_green(pr: PullRequest, baseline: RepoBaseline) -> GuardResult:
+    """G06 — every required context succeeded, and the required set has not shrunk.
+
+    A required check that is red, still running, or entirely absent from the PR
+    all block the merge — :meth:`PullRequest.failing_required` reports a missing
+    context as ``MISSING`` rather than silently treating it as passing.
+
+    A repo with no required contexts at all is refused outright: "CI is green"
+    carries no information when nothing is required, which is exactly BC-Arcade's
+    `dev` ruleset today.
+    """
+    if not baseline.required_contexts:
+        return GuardResult(
+            "G06",
+            False,
+            "repo declares no required status checks, so a green PR proves nothing",
+        )
+
+    failing = pr.failing_required(baseline.required_contexts)
+    if failing:
+        names = ", ".join(f"{c.name}={c.conclusion or c.status}" for c in failing)
+        return GuardResult("G06", False, f"required checks not green: {names}")
+    return GuardResult(
+        "G06", True, f"all {len(baseline.required_contexts)} required checks green"
+    )
+
+
+def guard_protection_unchanged(
+    baseline: RepoBaseline, live_contexts: frozenset[str]
+) -> GuardResult:
+    """G07 — branch protection's required-context set has not been weakened."""
+    removed = baseline.required_contexts - live_contexts
+    if removed:
+        return GuardResult(
+            "G07",
+            False,
+            f"required contexts removed since run start: {', '.join(sorted(removed))}",
+        )
+    return GuardResult("G07", True, "branch protection unchanged")
+
+
+def guard_head_sha_unchanged(pr: PullRequest, assessed_sha: str) -> GuardResult:
+    """G08 — the commit being merged is the one that was assessed and tested."""
+    if not assessed_sha:
+        return GuardResult("G08", False, "no assessed SHA recorded")
+    ok = pr.head_sha == assessed_sha
+    return GuardResult(
+        "G08",
+        ok,
+        "head SHA matches assessment"
+        if ok
+        else f"head moved {assessed_sha[:7]} -> {pr.head_sha[:7]} since assessment",
+    )
+
+
+def guard_thresholds_not_lowered(
+    baseline: RepoBaseline, current: dict[str, float]
+) -> GuardResult:
+    """G09 — numeric quality gates may rise or hold, never fall."""
+    lowered = [
+        f"{k}: {baseline.thresholds[k]} -> {v}"
+        for k, v in current.items()
+        if k in baseline.thresholds and v < baseline.thresholds[k]
+    ]
+    if lowered:
+        return GuardResult("G09", False, "thresholds lowered: " + "; ".join(lowered))
+    return GuardResult("G09", True, "no thresholds lowered")
+
+
+def guard_mergeable(pr: PullRequest) -> GuardResult:
+    """G10 — GitHub itself considers the PR cleanly mergeable.
+
+    ``UNSTABLE`` is accepted because it means a non-required check is red; the
+    required set is judged by G06, which is the set that actually gates merges.
+    """
+    if pr.mergeable.upper() == "CONFLICTING":
+        return GuardResult("G10", False, "PR has merge conflicts")
+    if pr.merge_state_status.upper() in ("DIRTY", "BLOCKED", "DRAFT"):
+        return GuardResult("G10", False, f"merge state is {pr.merge_state_status}")
+    if pr.merge_state_status.upper() == "BEHIND":
+        return GuardResult("G10", False, "branch is behind base; needs rebase first")
+    return GuardResult("G10", True, f"merge state {pr.merge_state_status or 'CLEAN'}")
+
+
+def guard_not_held(pr: PullRequest, hold_label: str = "dependabot-triage:hold") -> GuardResult:
+    """G11 — the manual kill switch on an individual PR."""
+    if hold_label in pr.labels:
+        return GuardResult("G11", False, f"{hold_label!r} label present")
+    return GuardResult("G11", True, "no hold label")
+
+
+# --------------------------------------------------------------------------
+# Aggregate
+# --------------------------------------------------------------------------
+
+
+def run_all_guards(
+    pr: PullRequest,
+    baseline: RepoBaseline,
+    assessed_sha: str,
+    live_contexts: frozenset[str] | None = None,
+    current_thresholds: dict[str, float] | None = None,
+    hold_label: str = "dependabot-triage:hold",
+) -> list[GuardResult]:
+    """Run every merge precondition. An empty failure list is the only path to merge."""
+    contexts = baseline.required_contexts if live_contexts is None else live_contexts
+    thresholds = current_thresholds if current_thresholds is not None else baseline.thresholds
+    return [
+        guard_author_is_dependabot(pr),
+        guard_paths_allowed(pr),
+        guard_no_denylisted_paths(pr),
+        guard_workflow_pins_only(pr),
+        guard_no_forbidden_patterns(pr),
+        guard_required_checks_green(pr, baseline),
+        guard_protection_unchanged(baseline, contexts),
+        guard_head_sha_unchanged(pr, assessed_sha),
+        guard_thresholds_not_lowered(baseline, thresholds),
+        guard_mergeable(pr),
+        guard_not_held(pr, hold_label),
+    ]
+
+
+def failures(results: list[GuardResult]) -> list[GuardResult]:
+    return [r for r in results if not r.passed]
+
+
+def may_merge(results: list[GuardResult]) -> bool:
+    return not failures(results)
+
+
+# --------------------------------------------------------------------------
+# Threshold extraction (used to build and re-check the baseline)
+# --------------------------------------------------------------------------
+
+
+def extract_thresholds(text: str) -> dict[str, float]:
+    """Pull numeric quality gates out of CI config or a manifest.
+
+    Where a key appears more than once the strictest (highest) value wins, so a
+    later loosened duplicate cannot mask a stricter earlier declaration.
+    """
+    found: dict[str, float] = {}
+    for key, pattern in THRESHOLD_PATTERNS:
+        for match in pattern.finditer(text):
+            value = float(match.group(1))
+            found[key] = max(found.get(key, value), value)
+    audit = re.search(r"--audit-level[= ](\w+)", text)
+    if audit and audit.group(1).lower() in AUDIT_LEVELS:
+        found["audit_level"] = float(AUDIT_LEVELS.index(audit.group(1).lower()))
+    return found
+
+
+def workflow_pin_changes(files: list[ChangedFile]) -> list[str]:
+    """Human-readable summary of the ``uses:`` pins a PR moves."""
+    out: list[str] = []
+    for f in files:
+        if not _is_workflow(f.path):
+            continue
+        for line in f.added_lines():
+            match = re.search(r"uses:\s*(\S+)@(\S+)", line)
+            if match:
+                out.append(f"{match.group(1)}@{match.group(2)}")
+    return out

--- a/dependabot-triage/harvest.py
+++ b/dependabot-triage/harvest.py
@@ -1,0 +1,220 @@
+"""Phase 1 — collect Dependabot PRs and the tamper baseline. No model involved.
+
+Everything the assessment and the guards need is gathered here, so a dry run can
+be replayed offline from the harvested JSON without touching GitHub again.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+
+import gh
+import guards
+from models import ChangedFile, CheckRun, PullRequest, RepoBaseline
+
+log = logging.getLogger(__name__)
+
+DIFF_HEADER_RE = re.compile(r"^diff --git a/(?P<a>.+?) b/(?P<b>.+)$")
+
+# Dependabot's title format, e.g.
+#   chore(deps): bump lodash from 4.17.20 to 4.17.21
+#   Bump actions/setup-python from 6 to 7
+BUMP_RE = re.compile(
+    r"bump\s+(?P<pkg>\S+)\s+from\s+(?P<from>\S+)\s+to\s+(?P<to>\S+)", re.IGNORECASE
+)
+
+ECOSYSTEM_LABELS = {
+    "javascript": "npm",
+    "npm_and_yarn": "npm",
+    "python": "pip",
+    "github_actions": "github-actions",
+    "ruby": "bundler",
+    "go": "gomod",
+    "swift": "swift",
+}
+
+
+@dataclass
+class RepoHarvest:
+    """Everything collected for one repo in a single pass."""
+
+    repo: str
+    base: str
+    merge_method: str
+    baseline: RepoBaseline
+    prs: list[PullRequest] = field(default_factory=list)
+
+    @property
+    def dependabot_prs(self) -> list[PullRequest]:
+        return [p for p in self.prs if p.author in guards.DEPENDABOT_AUTHORS]
+
+
+def split_diff(diff: str) -> dict[str, str]:
+    """Split a unified diff into ``{path: patch}``.
+
+    ``gh pr diff`` returns one blob for the whole PR; the guards reason per file,
+    so the blob is cut on ``diff --git`` boundaries. The *b*-side path is used, so
+    a rename reports its destination.
+    """
+    patches: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in diff.splitlines():
+        header = DIFF_HEADER_RE.match(line)
+        if header:
+            current = header.group("b")
+            patches.setdefault(current, [])
+            continue
+        if current is not None:
+            patches[current].append(line)
+    return {path: "\n".join(lines) for path, lines in patches.items()}
+
+
+def parse_bump(title: str) -> tuple[str, str, str]:
+    """Extract ``(package, from_version, to_version)`` from a Dependabot title."""
+    match = BUMP_RE.search(title)
+    if not match:
+        return ("", "", "")
+    return (match.group("pkg"), match.group("from"), match.group("to"))
+
+
+def detect_ecosystem(labels: list[str], paths: list[str]) -> str:
+    """Best-effort ecosystem, from Dependabot's own labels then from paths."""
+    for label in labels:
+        if label in ECOSYSTEM_LABELS:
+            return ECOSYSTEM_LABELS[label]
+    if any(p.startswith(".github/workflows/") for p in paths):
+        return "github-actions"
+    if any("package.json" in p or "lock" in p.lower() for p in paths):
+        return "npm"
+    if any("requirements" in p or "pyproject" in p or "Pipfile" in p for p in paths):
+        return "pip"
+    return "unknown"
+
+
+def _bucket_to_conclusion(check: dict) -> tuple[str, str]:
+    """Normalise ``gh pr checks`` output onto the CheckRun vocabulary."""
+    bucket = (check.get("bucket") or "").lower()
+    state = (check.get("state") or "").upper()
+    if bucket == "pass":
+        return "SUCCESS", "COMPLETED"
+    if bucket == "fail":
+        return state or "FAILURE", "COMPLETED"
+    if bucket == "skipping":
+        return "SKIPPED", "COMPLETED"
+    if bucket == "pending":
+        return "", "IN_PROGRESS"
+    if state in ("SUCCESS", "NEUTRAL", "SKIPPED"):
+        return state, "COMPLETED"
+    if state in ("QUEUED", "IN_PROGRESS", "PENDING"):
+        return "", "IN_PROGRESS"
+    return state or "UNKNOWN", "COMPLETED"
+
+
+def harvest_repo(
+    repo: str, owner: str, base: str, merge_method: str, *, fetch_diffs: bool = True
+) -> RepoHarvest:
+    """Collect open Dependabot PRs plus the repo's tamper baseline."""
+    log.info("harvesting %s/%s", owner, repo)
+
+    contexts = gh.required_contexts(repo, owner, base)
+    workflow_shas = gh.file_shas(repo, owner, ".github/workflows", base)
+    dependabot_sha = ""
+    for entry_path in (".github/dependabot.yml", ".github/dependabot.yaml"):
+        shas = gh.file_shas(repo, owner, ".github", base)
+        if entry_path in shas:
+            dependabot_sha = shas[entry_path]
+            break
+
+    thresholds: dict[str, float] = {}
+    for path in list(workflow_shas) + ["pyproject.toml", "package.json"]:
+        text = gh.file_text(repo, owner, path, base)
+        for key, value in guards.extract_thresholds(text).items():
+            thresholds[key] = max(thresholds.get(key, value), value)
+
+    baseline = RepoBaseline(
+        repo=repo,
+        required_contexts=contexts,
+        workflow_file_shas=workflow_shas,
+        dependabot_config_sha=dependabot_sha,
+        thresholds=thresholds,
+    )
+
+    prs: list[PullRequest] = []
+    for raw in gh.list_open_prs(repo, owner):
+        author = (raw.get("author") or {}).get("login", "")
+        if author in ("dependabot", "dependabot[bot]"):
+            author = "app/dependabot"
+        if author not in guards.DEPENDABOT_AUTHORS:
+            continue  # never touch a PR the agent did not author-check
+
+        number = raw["number"]
+        labels = [entry["name"] for entry in raw.get("labels") or []]
+        paths = [entry["path"] for entry in raw.get("files") or []]
+
+        patches: dict[str, str] = {}
+        if fetch_diffs:
+            try:
+                patches = split_diff(gh.pr_diff(repo, owner, number))
+            except gh.GhError as exc:
+                log.warning("no diff for %s#%s: %s", repo, number, exc)
+
+        files = [
+            ChangedFile(
+                path=entry["path"],
+                additions=entry.get("additions", 0),
+                deletions=entry.get("deletions", 0),
+                patch=patches.get(entry["path"], ""),
+            )
+            for entry in raw.get("files") or []
+        ]
+
+        checks = []
+        for entry in gh.pr_checks(repo, owner, number):
+            conclusion, status = _bucket_to_conclusion(entry)
+            checks.append(CheckRun(name=entry["name"], conclusion=conclusion, status=status))
+
+        prs.append(
+            PullRequest(
+                repo=repo,
+                number=number,
+                title=raw.get("title", ""),
+                author=author,
+                base_ref=raw.get("baseRefName", base),
+                head_sha=raw.get("headRefOid", ""),
+                files=files,
+                labels=labels,
+                checks=checks,
+                mergeable=raw.get("mergeable", "UNKNOWN"),
+                merge_state_status=raw.get("mergeStateStatus", "UNKNOWN"),
+                body=raw.get("body", "") or "",
+                ecosystem=detect_ecosystem(labels, paths),
+                is_group="group" in raw.get("title", "").lower(),
+            )
+        )
+
+    log.info("%s: %d Dependabot PR(s), %d required check(s)", repo, len(prs), len(contexts))
+    return RepoHarvest(
+        repo=repo, base=base, merge_method=merge_method, baseline=baseline, prs=prs
+    )
+
+
+def harvest_all(config: dict, *, fetch_diffs: bool = True) -> list[RepoHarvest]:
+    """Harvest every enabled repo. Disabled repos are skipped before any API call."""
+    owner = config["owner"]
+    out: list[RepoHarvest] = []
+    for entry in config["repos"]:
+        if not entry.get("enabled", False):
+            log.info("skipping %s (disabled in config)", entry["name"])
+            continue
+        out.append(
+            harvest_repo(
+                entry["name"],
+                owner,
+                entry.get("base", "dev"),
+                entry.get("merge_method", "squash"),
+                fetch_diffs=fetch_diffs,
+            )
+        )
+    return out

--- a/dependabot-triage/harvest.py
+++ b/dependabot-triage/harvest.py
@@ -195,9 +195,7 @@ def harvest_repo(
         )
 
     log.info("%s: %d Dependabot PR(s), %d required check(s)", repo, len(prs), len(contexts))
-    return RepoHarvest(
-        repo=repo, base=base, merge_method=merge_method, baseline=baseline, prs=prs
-    )
+    return RepoHarvest(repo=repo, base=base, merge_method=merge_method, baseline=baseline, prs=prs)
 
 
 def harvest_all(config: dict, *, fetch_diffs: bool = True) -> list[RepoHarvest]:

--- a/dependabot-triage/llm.py
+++ b/dependabot-triage/llm.py
@@ -1,0 +1,108 @@
+"""The only place the agent talks to Claude.
+
+Two properties make the rest of the system safe to reason about:
+
+* every call is charged against a :class:`~budget.Budget` before and after it runs,
+  so a ceiling cannot be bypassed by adding a new call site; and
+* every call returns parsed JSON validated against a schema, so a model response
+  can never be interpreted as a command. The executor consumes data, not prose.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import anthropic
+
+from budget import Budget
+
+log = logging.getLogger(__name__)
+
+# Retried automatically by the SDK; surfaced here so a sustained outage ends the
+# run instead of spinning against the wall clock.
+MAX_RETRIES = 3
+
+
+class ModelResponseInvalid(RuntimeError):
+    """The model returned something the schema does not allow."""
+
+
+class Client:
+    """Budget-aware Anthropic client."""
+
+    def __init__(self, budget: Budget, *, dry_run: bool = False) -> None:
+        self._client = anthropic.Anthropic(max_retries=MAX_RETRIES)
+        self.budget = budget
+        self.dry_run = dry_run
+
+    def count_tokens(self, model: str, system: str, prompt: str) -> int:
+        """Pre-flight size check, used to decide whether to chunk the corpus."""
+        result = self._client.messages.count_tokens(
+            model=model,
+            system=system,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return result.input_tokens
+
+    def complete(
+        self,
+        *,
+        phase: str,
+        model: str,
+        system: str,
+        prompt: str,
+        effort: str = "medium",
+        max_tokens: int = 8000,
+        cache_system: bool = False,
+        schema: dict[str, Any] | None = None,
+    ) -> tuple[Any, dict]:
+        """Run one call and return ``(parsed_content, usage)``.
+
+        ``cache_system`` marks the system prompt as a cache breakpoint. The risk
+        rubric is stable across nights and comfortably above the 1024-token
+        minimum, so it bills at roughly a tenth of list price after the first call.
+        """
+        self.budget.check_before_call()
+
+        system_blocks: list[dict[str, Any]] = [{"type": "text", "text": system}]
+        if cache_system:
+            system_blocks[0]["cache_control"] = {"type": "ephemeral"}
+
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "system": system_blocks,
+            "messages": [{"role": "user", "content": prompt}],
+            "output_config": {"effort": effort},
+        }
+        if schema is not None:
+            kwargs["output_config"]["format"] = {"type": "json_schema", "schema": schema}
+
+        log.info("%s: calling %s (effort=%s)", phase, model, effort)
+        response = self._client.messages.create(**kwargs)
+
+        usage = response.usage.model_dump() if hasattr(response.usage, "model_dump") else {}
+        self.budget.record(phase, model, usage)
+
+        if response.stop_reason == "refusal":
+            raise ModelResponseInvalid(
+                f"{phase}: request was declined by safety classifiers "
+                f"({getattr(response.stop_details, 'category', 'unknown')})"
+            )
+
+        text = "".join(block.text for block in response.content if block.type == "text")
+
+        if response.stop_reason == "max_tokens":
+            raise ModelResponseInvalid(
+                f"{phase}: response hit max_tokens ({max_tokens}); output is truncated"
+            )
+
+        if schema is None:
+            return text.strip(), usage
+
+        try:
+            return json.loads(text), usage
+        except json.JSONDecodeError as exc:
+            raise ModelResponseInvalid(f"{phase}: response was not valid JSON: {exc}") from exc

--- a/dependabot-triage/metrics.py
+++ b/dependabot-triage/metrics.py
@@ -1,0 +1,253 @@
+"""Phase 6 — persistent history, so "is this working?" has an answer.
+
+Two numbers matter, and only one of them is the one people ask for first.
+
+*Autonomy rate* — merged over eligible — answers "how much is the agent actually
+doing". *Precision* — merges that did not later have to be undone — answers
+whether the autonomy rate was earned. Optimising the first without watching the
+second is how an automation like this quietly becomes something you stop trusting.
+
+Attribution matters more than either total: recording which rubric question caused
+each non-merge tells you where the ceiling is, and therefore whether the fix is a
+better prompt or a configuration change.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from models import Action, Decision
+
+log = logging.getLogger(__name__)
+
+HISTORY_DIR = Path(__file__).parent / "history"
+
+
+def _month_file(when: datetime) -> Path:
+    return HISTORY_DIR / f"{when:%Y-%m}.jsonl"
+
+
+def _guard_summary(decision: Decision) -> list[dict]:
+    return [
+        {"guard_id": g.guard_id, "passed": g.passed, "detail": g.detail}
+        for g in decision.guard_results
+    ]
+
+
+def record_run(
+    decisions: list[Decision],
+    budget_summary: dict,
+    *,
+    run_id: str,
+    now: datetime,
+    dry_run: bool,
+    ci_seconds: dict[str, float] | None = None,
+) -> Path:
+    """Append one line per decision plus a run summary. Returns the file written."""
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    path = _month_file(now)
+    stamp = now.isoformat()
+
+    lines: list[str] = []
+    for decision in decisions:
+        lines.append(
+            json.dumps(
+                {
+                    "type": "decision",
+                    "run_id": run_id,
+                    "at": stamp,
+                    "dry_run": dry_run,
+                    "repo": decision.repo,
+                    "number": decision.number,
+                    "title": decision.title,
+                    "tier": decision.tier.value,
+                    "action": decision.action.value,
+                    "merged": decision.merged,
+                    "rebased": decision.rebased,
+                    "deferred": decision.deferred,
+                    "deciding_question": decision.deciding_question,
+                    "failed_guard": decision.failed_guard,
+                    "reason": decision.reason,
+                    "guards": _guard_summary(decision),
+                },
+                sort_keys=True,
+            )
+        )
+
+    stats = summarise(decisions)
+    lines.append(
+        json.dumps(
+            {
+                "type": "run",
+                "run_id": run_id,
+                "at": stamp,
+                "dry_run": dry_run,
+                "budget": budget_summary,
+                "ci_seconds": ci_seconds or {},
+                **stats,
+            },
+            sort_keys=True,
+        )
+    )
+
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+    log.info("wrote %d history line(s) to %s", len(lines), path.name)
+    return path
+
+
+def summarise(decisions: list[Decision]) -> dict:
+    """Per-run counts, including the autonomy rate and its attribution."""
+    merged = [d for d in decisions if d.merged]
+    deferred = [d for d in decisions if d.deferred]
+    blocked = [d for d in decisions if d.action is Action.SKIP]
+
+    # A PR that was already red before the run started, through no fault of the
+    # bump, was never mergeable tonight — counting it against the agent would
+    # make the autonomy rate measure repo health rather than agent behaviour.
+    eligible = [d for d in decisions if not d.deferred]
+
+    return {
+        "seen": len(decisions),
+        "merged": len(merged),
+        "rebased_then_merged": len([d for d in merged if d.rebased]),
+        "deferred": len(deferred),
+        "blocked_by_guard": len(blocked),
+        "eligible": len(eligible),
+        "autonomy_rate": round(len(merged) / len(eligible), 4) if eligible else None,
+        "by_tier": dict(Counter(d.tier.value for d in decisions)),
+        "by_deciding_question": dict(
+            Counter(
+                d.deciding_question for d in decisions if d.deciding_question not in ("", "NONE")
+            )
+        ),
+        "by_failed_guard": dict(Counter(d.failed_guard for d in blocked if d.failed_guard)),
+        "by_repo": dict(Counter(d.repo for d in decisions)),
+    }
+
+
+def load_history(since: datetime | None = None) -> list[dict]:
+    """Read every history line, optionally filtered to entries after ``since``."""
+    if not HISTORY_DIR.exists():
+        return []
+    entries: list[dict] = []
+    for path in sorted(HISTORY_DIR.glob("*.jsonl")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                log.warning("skipping malformed history line in %s", path.name)
+                continue
+            if since is not None:
+                try:
+                    when = datetime.fromisoformat(entry["at"])
+                except (KeyError, ValueError):
+                    continue
+                if when < since:
+                    continue
+            entries.append(entry)
+    return entries
+
+
+def rolling(days: int = 30, now: datetime | None = None) -> dict:
+    """Rolling window used in the email header.
+
+    Dry-run entries are excluded: they describe what the agent *would* have done,
+    and mixing them into the live rate would overstate it.
+    """
+    now = now or datetime.now(UTC)
+    since = now - timedelta(days=days)
+    decisions = [
+        e for e in load_history(since) if e.get("type") == "decision" and not e.get("dry_run")
+    ]
+    if not decisions:
+        return {"window_days": days, "decisions": 0, "autonomy_rate": None, "merged": 0}
+
+    merged = [d for d in decisions if d.get("merged")]
+    eligible = [d for d in decisions if not d.get("deferred")]
+    return {
+        "window_days": days,
+        "decisions": len(decisions),
+        "merged": len(merged),
+        "eligible": len(eligible),
+        "autonomy_rate": round(len(merged) / len(eligible), 4) if eligible else None,
+        "by_deciding_question": dict(
+            Counter(
+                d.get("deciding_question")
+                for d in decisions
+                if d.get("deciding_question") not in (None, "", "NONE")
+            )
+        ),
+        "by_failed_guard": dict(
+            Counter(d.get("failed_guard") for d in decisions if d.get("failed_guard"))
+        ),
+    }
+
+
+def month_to_date_spend(now: datetime | None = None) -> float:
+    """Spend already booked this calendar month, for the monthly ceiling."""
+    now = now or datetime.now(UTC)
+    total = 0.0
+    for entry in load_history():
+        if entry.get("type") != "run" or entry.get("dry_run"):
+            continue
+        try:
+            when = datetime.fromisoformat(entry["at"])
+        except (KeyError, ValueError):
+            continue
+        if (when.year, when.month) != (now.year, now.month):
+            continue
+        total += float((entry.get("budget") or {}).get("run_usd", 0.0))
+    return round(total, 4)
+
+
+def record_regression(repo: str, number: int, run_id: str, note: str, now: datetime) -> None:
+    """Mark a previously merged PR as having caused a problem.
+
+    Written by the follow-up check that looks for a red base branch or a revert in
+    the seven days after a merge. This is what turns the precision number from an
+    assumption into a measurement.
+    """
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    with _month_file(now).open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "type": "regression",
+                    "run_id": run_id,
+                    "at": now.isoformat(),
+                    "repo": repo,
+                    "number": number,
+                    "note": note,
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )
+
+
+def precision(days: int = 30, now: datetime | None = None) -> dict:
+    """Share of merges that did not have to be undone."""
+    now = now or datetime.now(UTC)
+    since = now - timedelta(days=days)
+    entries = load_history(since)
+    merged = [
+        e
+        for e in entries
+        if e.get("type") == "decision" and e.get("merged") and not e.get("dry_run")
+    ]
+    regressions = [e for e in entries if e.get("type") == "regression"]
+    if not merged:
+        return {"window_days": days, "merged": 0, "regressions": 0, "precision": None}
+    return {
+        "window_days": days,
+        "merged": len(merged),
+        "regressions": len(regressions),
+        "precision": round(1 - len(regressions) / len(merged), 4),
+    }

--- a/dependabot-triage/models.py
+++ b/dependabot-triage/models.py
@@ -1,0 +1,195 @@
+"""Shared data structures for the Dependabot triage agent.
+
+Every module in this package speaks in these types. Nothing here performs I/O or
+calls a model; that keeps the objects trivially constructible in tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class RiskTier(str, Enum):
+    """Assessment outcome. Only LOW is ever eligible for an automated merge."""
+
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    BLOCKED = "BLOCKED"
+
+
+class Action(str, Enum):
+    """The complete action vocabulary available to the executor.
+
+    The assessment model emits one of these and nothing else. Anything outside
+    this set is a schema violation that aborts the run — the model can never
+    express "run this shell command" or "write this file".
+    """
+
+    COMMENT = "COMMENT"
+    REBASE = "REBASE"
+    MERGE = "MERGE"
+    SKIP = "SKIP"
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    """One file in a pull request, with its unified-diff patch when available."""
+
+    path: str
+    additions: int = 0
+    deletions: int = 0
+    patch: str = ""
+
+    def added_lines(self) -> list[str]:
+        """Lines introduced by this PR, without the leading ``+``."""
+        return [
+            line[1:]
+            for line in self.patch.splitlines()
+            if line.startswith("+") and not line.startswith("+++")
+        ]
+
+    def changed_lines(self) -> list[str]:
+        """Added *and* removed lines, leading marker retained."""
+        return [
+            line
+            for line in self.patch.splitlines()
+            if (line.startswith("+") and not line.startswith("+++"))
+            or (line.startswith("-") and not line.startswith("---"))
+        ]
+
+
+@dataclass(frozen=True)
+class CheckRun:
+    """A single status check on the PR head."""
+
+    name: str
+    conclusion: str  # SUCCESS | FAILURE | SKIPPED | NEUTRAL | CANCELLED | ""
+    status: str = "COMPLETED"  # QUEUED | IN_PROGRESS | COMPLETED
+
+    @property
+    def is_success(self) -> bool:
+        return self.conclusion.upper() in ("SUCCESS", "NEUTRAL", "SKIPPED")
+
+    @property
+    def is_settled(self) -> bool:
+        return self.status.upper() == "COMPLETED"
+
+
+@dataclass(frozen=True)
+class RepoBaseline:
+    """Tamper baseline captured for a repo at the start of the run.
+
+    Re-checked at the end of the run; any drift aborts everything (guard L4).
+    """
+
+    repo: str
+    required_contexts: frozenset[str]
+    workflow_file_shas: dict[str, str] = field(default_factory=dict)
+    dependabot_config_sha: str = ""
+    thresholds: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class PullRequest:
+    """A Dependabot pull request plus everything needed to judge it."""
+
+    repo: str
+    number: int
+    title: str
+    author: str
+    base_ref: str
+    head_sha: str
+    files: list[ChangedFile] = field(default_factory=list)
+    labels: list[str] = field(default_factory=list)
+    checks: list[CheckRun] = field(default_factory=list)
+    mergeable: str = "UNKNOWN"  # MERGEABLE | CONFLICTING | UNKNOWN
+    merge_state_status: str = "UNKNOWN"  # CLEAN | UNSTABLE | BEHIND | BLOCKED | DIRTY
+    body: str = ""
+    ecosystem: str = ""  # npm | pip | github-actions | ...
+    is_group: bool = False
+
+    @property
+    def slug(self) -> str:
+        return f"{self.repo}#{self.number}"
+
+    @property
+    def paths(self) -> list[str]:
+        return [f.path for f in self.files]
+
+    def failing_required(self, required: frozenset[str]) -> list[CheckRun]:
+        """Required checks that did not succeed.
+
+        A required context with no matching check run counts as failing — a
+        missing check is never treated as a passing one.
+        """
+        by_name = {c.name: c for c in self.checks}
+        out: list[CheckRun] = []
+        for name in sorted(required):
+            run = by_name.get(name)
+            if run is None:
+                out.append(CheckRun(name=name, conclusion="MISSING", status="COMPLETED"))
+            elif not (run.is_settled and run.is_success):
+                out.append(run)
+        return out
+
+
+@dataclass(frozen=True)
+class GuardResult:
+    """Outcome of one deterministic precondition."""
+
+    guard_id: str
+    passed: bool
+    detail: str = ""
+
+    def __str__(self) -> str:  # pragma: no cover - display only
+        mark = "pass" if self.passed else "FAIL"
+        return f"[{self.guard_id}] {mark}: {self.detail}"
+
+
+@dataclass
+class Assessment:
+    """The model's judgment for one PR, before any guard has run."""
+
+    repo: str
+    number: int
+    tier: RiskTier
+    merge_order: int
+    rationale: str
+    deciding_question: str = ""
+    evidence: dict[str, str] = field(default_factory=dict)
+    packages: list[str] = field(default_factory=list)
+
+    @property
+    def slug(self) -> str:
+        return f"{self.repo}#{self.number}"
+
+
+@dataclass
+class Decision:
+    """Final record for one PR — what happened and why. One ledger line."""
+
+    repo: str
+    number: int
+    title: str
+    tier: RiskTier
+    action: Action
+    reason: str
+    guard_results: list[GuardResult] = field(default_factory=list)
+    rebased: bool = False
+    merged: bool = False
+    deferred: bool = False
+    deciding_question: str = ""
+    diagnosis: str = ""
+
+    @property
+    def slug(self) -> str:
+        return f"{self.repo}#{self.number}"
+
+    @property
+    def failed_guard(self) -> str:
+        for g in self.guard_results:
+            if not g.passed:
+                return g.guard_id
+        return ""

--- a/dependabot-triage/models.py
+++ b/dependabot-triage/models.py
@@ -7,10 +7,10 @@ calls a model; that keeps the objects trivially constructible in tests.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 
-class RiskTier(str, Enum):
+class RiskTier(StrEnum):
     """Assessment outcome. Only LOW is ever eligible for an automated merge."""
 
     LOW = "LOW"
@@ -19,7 +19,7 @@ class RiskTier(str, Enum):
     BLOCKED = "BLOCKED"
 
 
-class Action(str, Enum):
+class Action(StrEnum):
     """The complete action vocabulary available to the executor.
 
     The assessment model emits one of these and nothing else. Anything outside

--- a/dependabot-triage/prompts/adversary.md
+++ b/dependabot-triage/prompts/adversary.md
@@ -1,0 +1,21 @@
+A separate reviewer has classified the pull request below as LOW risk, meaning it will be merged tonight without anyone looking at it.
+
+Your job is to argue the opposite. Find the concrete reason this merge is unsafe.
+
+You are not being asked to be agreeable or to confirm the other reviewer's work. A second opinion that always agrees is worth nothing. Look specifically for what a reviewer working through a queue at speed would miss:
+
+- a sibling package that needed bumping in the same PR and was not
+- a peer-dependency or engine constraint the lockfile satisfies but the runtime will not
+- a group PR whose headline says "patch" while one member is a major
+- a package whose breakage would not surface in this repo's required checks
+- a changelog entry that mentions a behavioural change without calling it breaking
+- a version published so recently that nobody has exercised it yet
+
+State your objection only if it is **concrete and checkable** — name the package, the constraint, and what would break. "It could theoretically break something" is not an objection; it applies to every change ever made and is therefore useless.
+
+If you genuinely cannot find a specific problem, say so plainly. A false alarm costs a merge that should have happened, and enough of those make this system worth ignoring.
+
+Respond with exactly one of:
+
+- `SAFE` — followed by one sentence confirming you looked and found nothing specific.
+- `UNSAFE: <objection>` — one sentence naming the package, the specific risk, and what breaks.

--- a/dependabot-triage/prompts/assess.md
+++ b/dependabot-triage/prompts/assess.md
@@ -1,0 +1,39 @@
+You are triaging Dependabot pull requests across a small personal software stack. You classify risk. You do not merge, edit files, or run commands — a separate deterministic layer does that, and it re-verifies everything you say before acting on it.
+
+Classify every pull request you are given into exactly one tier.
+
+## Tiers
+
+- **LOW** — merging this unattended tonight is safe. Reserved for changes whose failure mode is caught by the repo's existing required checks.
+- **MEDIUM** — probably fine, but wants a human eye. Anything you are not confident about belongs here.
+- **HIGH** — a real chance of breaking something that CI would not catch.
+- **BLOCKED** — must not merge: the diff touches something outside the dependency manifests, or a precondition is plainly unmet.
+
+Only LOW is eligible for automated merge. **When you are uncertain between two tiers, pick the higher one.** A PR left for the morning costs a few minutes. A bad merge at 1am costs a debugging session, and it costs trust in this whole system.
+
+## The rubric
+
+Answer these for each PR. Record your reasoning for Q1, Q3, Q5, and Q12 in every case; record the others when they are what moved the tier.
+
+1. **Q1_semver** — Is this major, minor, patch, or prerelease? A major is never LOW.
+2. **Q2_transitive** — Direct manifest bump, or a transitive lockfile-only change? Transitive-only rarely reaches your call sites.
+3. **Q3_ecosystem** — Blast radius by ecosystem, loosest to tightest: `github-actions` (CI only, no runtime) < devDependencies < dependencies < Python runtime.
+4. **Q4_runtime_path** — Does this package execute in production, or only during build and test?
+5. **Q5_peer_coupling** — Does this bump require a sibling bump that is *not* in this PR? Watch for `react` / `react-dom` / `@types/react`, the Expo SDK family, `eslint` and its plugins, `vite` and its plugins, `pytest` and its plugins. A half-applied family upgrade is the single most common way a green CI still ships a broken build.
+6. **Q6_group** — Is this a grouped PR? Risk is the **maximum** across members, never the average. One major in a group of nine patches makes the whole group a major.
+7. **Q7_stray_paths** — Does the diff touch anything beyond manifests, lockfiles, and `uses:` version pins in workflow files? If yes, tier is BLOCKED regardless of everything else.
+8. **Q8_security_surface** — Is this package on the auth, crypto, SQL, or serialization path? A patch to `jsonwebtoken` or `sqlalchemy` deserves more caution than a minor to `chalk`.
+9. **Q9_changelog** — Does the release note mention breaking changes, deprecations, or a raised Node/Python floor? The PR body contains Dependabot's extract; read it.
+10. **Q10_pinned_runtime** — Does this move a pinned runtime other tooling depends on (Expo SDK, Node major, Python minor)?
+11. **Q11_ordering** — Must this merge before or after another PR in this batch? Set `merge_order` accordingly, ascending, within each repo.
+12. **Q12_ci_coverage** — Would this repo's required checks actually catch a break in this package? A repo with few or no required checks cannot support a LOW rating for anything that reaches runtime — green CI there is weak evidence.
+13. **Q13_version_age** — Was the target version published within the last 72 hours? Fresh releases carry both regression and supply-chain risk; prefer MEDIUM.
+14. **Q14_deploy_reach** — Does merging reach a Render deploy? Merges into `dev` do not; merges into `main` do.
+
+## Output
+
+Emit one assessment per pull request supplied, matching the provided schema exactly.
+
+- `deciding_question` names the rubric question that drove the tier. Use `NONE` only when the tier is LOW.
+- `rationale` is one sentence and will be posted verbatim as a PR comment and shown in an email. Write it for a reader who has not seen the diff. Say what the change is and why it landed in this tier.
+- `packages` lists the resolved `name@version` entries this PR moves. It is used to detect drift if Dependabot rebases the branch, so be precise.

--- a/dependabot-triage/prompts/diagnose.md
+++ b/dependabot-triage/prompts/diagnose.md
@@ -1,0 +1,15 @@
+A Dependabot pull request has a failing CI check. Explain why, in a comment that will be posted on the PR.
+
+The single most useful thing you can determine is whether **this bump caused the failure, or whether the check was already failing before it**. A pre-existing failure means the PR is fine and the repo has an unrelated problem; a caused failure means the bump needs work. Getting this backwards sends someone down the wrong path, so say which one it is and what evidence told you.
+
+Write three short paragraphs at most:
+
+1. What failed, concretely — the job, and the actual error, not a restatement of "the build failed".
+2. Whether the bump caused it. If the error has no connection to the packages this PR moves, say so plainly.
+3. What would fix it, and whether that fix would be confined to dependency manifests or would need a source change. This matters because the agent may only rebase; anything requiring a source edit is a human's job.
+
+If the logs do not contain enough to tell, say that rather than guessing. A confident wrong diagnosis is worse than an admission that the logs were unhelpful.
+
+Do not suggest disabling, skipping, or relaxing the failing check. If the check is genuinely wrong, say that the check looks wrong and why — but the fix is never to turn it off.
+
+End your response with a line reading exactly `CONFIDENCE: HIGH`, `CONFIDENCE: MEDIUM`, or `CONFIDENCE: LOW`.

--- a/dependabot-triage/prompts/summary.md
+++ b/dependabot-triage/prompts/summary.md
@@ -1,0 +1,11 @@
+Write the opening paragraph of a nightly automation email. The reader is the one person who maintains all of these repositories, reading on their phone before they have decided whether tonight's run needs their attention.
+
+You will be given the run's counts. Write at most three sentences.
+
+Lead with whether anything needs them. If nothing does — everything merged cleanly, or there was simply nothing to do — say that in the first sentence and keep the rest very short. If something does, name it specifically: which repository, which pull request, what the obstacle is.
+
+Do not restate the numbers. They appear in a table directly below your paragraph, and repeating them wastes the only sentences you have. Use them to decide what is worth mentioning.
+
+Do not congratulate the system, editorialise about how smoothly things went, or add a closing pleasantry. Write it the way a colleague who ran the job would mention the result in passing.
+
+If a run aborted, a spend ceiling was hit, or a tamper tripwire fired, that is the only thing your paragraph should be about.

--- a/dependabot-triage/pyproject.toml
+++ b/dependabot-triage/pyproject.toml
@@ -1,0 +1,40 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q --cov=. --cov-report=term-missing --cov-fail-under=80"
+
+[tool.coverage.run]
+# gh.py and llm.py are pure adapters: one translates to `gh` subprocess calls,
+# the other to Anthropic SDK calls. Unit tests over them would assert the
+# behaviour of a mock rather than of the code, so they are verified by the dry
+# run against live repos instead. Everything that makes a *decision* — guards,
+# execute, assess, metrics, report — is covered here, and guards.py is held at
+# 100% separately by the workflow.
+omit = ["tests/*", "__main__.py", "gh.py", "llm.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B", "S", "C4", "SIM"]
+ignore = [
+    "S101", # assert is the point of a test suite
+    "E501", # line length is enforced by the formatter
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S105", "S106"]
+# gh._run is the single audited subprocess call site; it always passes an
+# argument list and never shell=True.
+"gh.py" = ["S603", "S607"]

--- a/dependabot-triage/report.py
+++ b/dependabot-triage/report.py
@@ -1,0 +1,220 @@
+"""Phase 5 — one email covering the whole stack.
+
+Every number and every reason in the email is rendered from the ledger in code.
+The model contributes exactly one paragraph of prose, so the report cannot
+misstate what happened even if the model is having an off night.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+from llm import Client
+from models import Action, Decision, RiskTier
+
+log = logging.getLogger(__name__)
+
+SUMMARY_PROMPT = (Path(__file__).parent / "prompts" / "summary.md").read_text(encoding="utf-8")
+RESEND_ENDPOINT = "https://api.resend.com/emails"
+
+TIER_BADGE = {
+    RiskTier.LOW: ("#1a7f37", "LOW"),
+    RiskTier.MEDIUM: ("#9a6700", "MEDIUM"),
+    RiskTier.HIGH: ("#bc4c00", "HIGH"),
+    RiskTier.BLOCKED: ("#cf222e", "BLOCKED"),
+}
+ACTION_MARK = {
+    Action.MERGE: ("#1a7f37", "merged"),
+    Action.COMMENT: ("#9a6700", "left for review"),
+    Action.SKIP: ("#cf222e", "refused"),
+    Action.REBASE: ("#0969da", "rebasing"),
+}
+
+
+def _esc(text: str) -> str:
+    return html.escape(text or "", quote=True)
+
+
+def _pct(value: float | None) -> str:
+    return "—" if value is None else f"{value * 100:.0f}%"
+
+
+def compose_summary(stats: dict, client: Client | None, config: dict, aborted: str = "") -> str:
+    """One paragraph of prose. Falls back to a deterministic sentence if unavailable."""
+    if aborted:
+        return f"The run stopped early: {aborted}. Nothing further was merged."
+    if client is None:
+        return "Nightly Dependabot triage completed."
+
+    prompt = json.dumps(stats, indent=2, sort_keys=True)
+    try:
+        text, _ = client.complete(
+            phase="summary",
+            model=config["models"]["summary"],
+            system=SUMMARY_PROMPT,
+            prompt=prompt,
+            effort=config["effort"]["summary"],
+            max_tokens=300,
+        )
+        return str(text).strip()
+    except Exception as exc:  # noqa: BLE001 - the email must go out regardless
+        log.warning("summary generation failed, using fallback: %s", exc)
+        return "Nightly Dependabot triage completed; see the table below."
+
+
+def _decision_row(decision: Decision, run_url: str) -> str:
+    colour, label = ACTION_MARK.get(decision.action, ("#57606a", decision.action.value))
+    tier_colour, tier_label = TIER_BADGE[decision.tier]
+    ref = f"#{decision.number}"
+    reason = _esc(decision.reason)
+    if decision.deciding_question and decision.deciding_question != "NONE":
+        reason += f' <span style="color:#57606a">({_esc(decision.deciding_question)})</span>'
+    if decision.failed_guard:
+        reason += f' <span style="color:#cf222e">[{_esc(decision.failed_guard)}]</span>'
+    return (
+        "<tr>"
+        f'<td style="padding:6px 10px;white-space:nowrap"><code>{ref}</code></td>'
+        f'<td style="padding:6px 10px">{_esc(decision.title)}</td>'
+        f'<td style="padding:6px 10px;white-space:nowrap;color:{tier_colour};font-weight:600">{tier_label}</td>'
+        f'<td style="padding:6px 10px;white-space:nowrap;color:{colour}">{label}</td>'
+        f'<td style="padding:6px 10px;color:#57606a">{reason}</td>'
+        "</tr>"
+    )
+
+
+def render_html(
+    *,
+    summary: str,
+    decisions: list[Decision],
+    stats: dict,
+    rolling: dict,
+    precision: dict,
+    budget: dict,
+    run_url: str,
+    when: datetime,
+    dry_run: bool,
+    aborted: str = "",
+) -> str:
+    """Build the email body. Pure function over the ledger — no I/O, no model."""
+    by_repo: dict[str, list[Decision]] = {}
+    for decision in decisions:
+        by_repo.setdefault(decision.repo, []).append(decision)
+
+    banner = ""
+    if aborted:
+        banner = (
+            '<div style="background:#ffebe9;border:1px solid #cf222e;padding:12px;'
+            'border-radius:6px;margin-bottom:16px"><strong>Run aborted:</strong> '
+            f"{_esc(aborted)}</div>"
+        )
+    elif dry_run:
+        banner = (
+            '<div style="background:#ddf4ff;border:1px solid #0969da;padding:12px;'
+            'border-radius:6px;margin-bottom:16px"><strong>Dry run</strong> — '
+            "decisions below were not carried out.</div>"
+        )
+
+    head = (
+        f'<span style="color:#1a7f37">{stats["merged"]} merged</span> · '
+        f'{stats["seen"] - stats["merged"] - stats["blocked_by_guard"]} left for review · '
+        f'<span style="color:#cf222e">{stats["blocked_by_guard"]} refused</span>'
+    )
+
+    sections: list[str] = []
+    for repo in sorted(by_repo):
+        items = by_repo[repo]
+        merged = sum(1 for d in items if d.merged)
+        note = f"{merged} merged" if merged else "nothing merged"
+        rows = "".join(_decision_row(d, run_url) for d in items)
+        sections.append(
+            f'<h3 style="margin:22px 0 6px;font-size:15px">{_esc(repo)} '
+            f'<span style="font-weight:400;color:#57606a">— {len(items)} PR(s), {note}</span></h3>'
+            '<table style="border-collapse:collapse;width:100%;font-size:13px">'
+            f"{rows}</table>"
+        )
+    if not sections:
+        sections.append('<p style="color:#57606a">No open Dependabot pull requests.</p>')
+
+    return f"""<!doctype html>
+<html><body style="font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;
+color:#1f2328;max-width:760px;margin:0 auto;padding:20px">
+<h2 style="margin:0 0 4px;font-size:18px">Dependabot Triage — {when:%a %d %b %Y}</h2>
+<p style="margin:0 0 16px;color:#57606a;font-size:13px">{head}</p>
+{banner}
+<p style="font-size:14px;line-height:1.55">{_esc(summary)}</p>
+<table style="border-collapse:collapse;font-size:13px;margin:18px 0;width:100%">
+<tr style="background:#f6f8fa">
+  <td style="padding:8px 10px">Autonomy rate ({rolling.get('window_days', 30)}d)</td>
+  <td style="padding:8px 10px;font-weight:600">{_pct(rolling.get('autonomy_rate'))}</td>
+  <td style="padding:8px 10px">Precision</td>
+  <td style="padding:8px 10px;font-weight:600">{_pct(precision.get('precision'))}</td>
+</tr>
+<tr>
+  <td style="padding:8px 10px">Spend tonight</td>
+  <td style="padding:8px 10px;font-weight:600">${budget.get('run_usd', 0):.2f}</td>
+  <td style="padding:8px 10px">Month to date</td>
+  <td style="padding:8px 10px;font-weight:600">${budget.get('month_usd', 0):.2f}
+      <span style="color:#57606a;font-weight:400">/ ${budget.get('max_per_month', 0):.2f}</span></td>
+</tr>
+</table>
+{''.join(sections)}
+<hr style="border:0;border-top:1px solid #d0d7de;margin:24px 0">
+<p style="font-size:12px;color:#57606a">
+  <a href="{_esc(run_url)}">Run log</a> · ledger attached as a workflow artifact ·
+  the agent may only comment, request a Dependabot rebase, and merge — it never edits a file.
+</p>
+</body></html>"""
+
+
+def send(html_body: str, subject: str, config: dict, *, dry_run: bool = True) -> bool:
+    """Deliver via Resend. Returns True when the email was accepted."""
+    api_key = os.environ.get("RESEND_API_KEY", "")
+    if dry_run or not api_key:
+        reason = "dry run" if dry_run else "RESEND_API_KEY not set"
+        log.info("not sending email (%s); subject was %r", reason, subject)
+        return False
+
+    payload = json.dumps(
+        {
+            "from": config["report"]["from_address"],
+            "to": [config["report"]["to_address"]],
+            "subject": subject,
+            "html": html_body,
+        }
+    ).encode("utf-8")
+
+    request = urllib.request.Request(  # noqa: S310 - fixed HTTPS endpoint
+        RESEND_ENDPOINT,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+            log.info("email accepted by Resend (%s)", response.status)
+            return True
+    except urllib.error.HTTPError as exc:
+        log.error("Resend rejected the email (%s): %s", exc.code, exc.read().decode())
+    except urllib.error.URLError as exc:
+        log.error("could not reach Resend: %s", exc)
+    return False
+
+
+def subject_line(stats: dict, config: dict, when: datetime, aborted: str = "") -> str:
+    prefix = config["report"]["subject_prefix"]
+    if aborted:
+        return f"{prefix} — ABORTED — {when:%a %d %b}"
+    return (
+        f"{prefix} — {stats['merged']} merged, "
+        f"{stats['seen'] - stats['merged']} pending — {when:%a %d %b}"
+    )

--- a/dependabot-triage/requirements.txt
+++ b/dependabot-triage/requirements.txt
@@ -1,0 +1,2 @@
+anthropic>=0.116.0
+PyYAML>=6.0.2

--- a/dependabot-triage/schema/assessment.schema.json
+++ b/dependabot-triage/schema/assessment.schema.json
@@ -1,0 +1,89 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["assessments"],
+  "properties": {
+    "assessments": {
+      "type": "array",
+      "description": "One entry per pull request supplied, in any order.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "repo",
+          "number",
+          "tier",
+          "merge_order",
+          "rationale",
+          "deciding_question",
+          "packages",
+          "evidence"
+        ],
+        "properties": {
+          "repo": { "type": "string" },
+          "number": { "type": "integer" },
+          "tier": {
+            "type": "string",
+            "enum": ["LOW", "MEDIUM", "HIGH", "BLOCKED"],
+            "description": "Only LOW is eligible for an automated merge."
+          },
+          "merge_order": {
+            "type": "integer",
+            "description": "Ascending order within a repo. Equal values mean order does not matter."
+          },
+          "rationale": {
+            "type": "string",
+            "description": "One sentence, written for the PR comment and the email."
+          },
+          "deciding_question": {
+            "type": "string",
+            "enum": [
+              "Q1_semver",
+              "Q2_transitive",
+              "Q3_ecosystem",
+              "Q4_runtime_path",
+              "Q5_peer_coupling",
+              "Q6_group",
+              "Q7_stray_paths",
+              "Q8_security_surface",
+              "Q9_changelog",
+              "Q10_pinned_runtime",
+              "Q11_ordering",
+              "Q12_ci_coverage",
+              "Q13_version_age",
+              "Q14_deploy_reach",
+              "NONE"
+            ],
+            "description": "Which rubric question drove the tier. NONE only when tier is LOW."
+          },
+          "packages": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Resolved package@version list, used to detect drift after a rebase."
+          },
+          "evidence": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["Q1_semver", "Q3_ecosystem", "Q5_peer_coupling", "Q12_ci_coverage"],
+            "properties": {
+              "Q1_semver": { "type": "string" },
+              "Q2_transitive": { "type": "string" },
+              "Q3_ecosystem": { "type": "string" },
+              "Q4_runtime_path": { "type": "string" },
+              "Q5_peer_coupling": { "type": "string" },
+              "Q6_group": { "type": "string" },
+              "Q7_stray_paths": { "type": "string" },
+              "Q8_security_surface": { "type": "string" },
+              "Q9_changelog": { "type": "string" },
+              "Q10_pinned_runtime": { "type": "string" },
+              "Q11_ordering": { "type": "string" },
+              "Q12_ci_coverage": { "type": "string" },
+              "Q13_version_age": { "type": "string" },
+              "Q14_deploy_reach": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/dependabot-triage/tests/conftest.py
+++ b/dependabot-triage/tests/conftest.py
@@ -32,14 +32,14 @@ def green_checks(required: frozenset[str] = REQUIRED) -> list[CheckRun]:
 
 def make_pr(**overrides) -> PullRequest:
     """A clean, mergeable npm patch bump that passes every guard."""
-    defaults = dict(
-        repo="buffingchi_site",
-        number=101,
-        title="chore(deps): bump lodash from 4.17.20 to 4.17.21",
-        author="app/dependabot",
-        base_ref="dev",
-        head_sha="a" * 40,
-        files=[
+    defaults = {
+        "repo": "buffingchi_site",
+        "number": 101,
+        "title": "chore(deps): bump lodash from 4.17.20 to 4.17.21",
+        "author": "app/dependabot",
+        "base_ref": "dev",
+        "head_sha": "a" * 40,
+        "files": [
             ChangedFile(
                 path="package.json",
                 additions=1,
@@ -48,24 +48,24 @@ def make_pr(**overrides) -> PullRequest:
             ),
             ChangedFile(path="package-lock.json", additions=8, deletions=8, patch=""),
         ],
-        labels=["dependencies", "javascript"],
-        checks=green_checks(),
-        mergeable="MERGEABLE",
-        merge_state_status="CLEAN",
-        ecosystem="npm",
-    )
+        "labels": ["dependencies", "javascript"],
+        "checks": green_checks(),
+        "mergeable": "MERGEABLE",
+        "merge_state_status": "CLEAN",
+        "ecosystem": "npm",
+    }
     defaults.update(overrides)
     return PullRequest(**defaults)
 
 
 def make_baseline(**overrides) -> RepoBaseline:
-    defaults = dict(
-        repo="buffingchi_site",
-        required_contexts=REQUIRED,
-        workflow_file_shas={".github/workflows/ci.yml": "deadbeef"},
-        dependabot_config_sha="cafebabe",
-        thresholds={"cov_fail_under": 80.0},
-    )
+    defaults = {
+        "repo": "buffingchi_site",
+        "required_contexts": REQUIRED,
+        "workflow_file_shas": {".github/workflows/ci.yml": "deadbeef"},
+        "dependabot_config_sha": "cafebabe",
+        "thresholds": {"cov_fail_under": 80.0},
+    }
     defaults.update(overrides)
     return RepoBaseline(**defaults)
 

--- a/dependabot-triage/tests/conftest.py
+++ b/dependabot-triage/tests/conftest.py
@@ -1,0 +1,91 @@
+"""Fixtures shared across the triage test suite.
+
+The builders below construct realistic PR payloads cheaply so individual tests
+read as "this specific thing is wrong with this PR" rather than a wall of setup.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# The package is a flat module directory rather than an installed distribution,
+# so make it importable without a packaging step.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from models import ChangedFile, CheckRun, PullRequest, RepoBaseline  # noqa: E402
+
+REQUIRED = frozenset(
+    {
+        "lint / Lint frontend (eslint + prettier)",
+        "test / Test frontend (jest/vitest)",
+        "secret-scan / Secret scan (gitleaks)",
+    }
+)
+
+
+def green_checks(required: frozenset[str] = REQUIRED) -> list[CheckRun]:
+    return [CheckRun(name=n, conclusion="SUCCESS", status="COMPLETED") for n in sorted(required)]
+
+
+def make_pr(**overrides) -> PullRequest:
+    """A clean, mergeable npm patch bump that passes every guard."""
+    defaults = dict(
+        repo="buffingchi_site",
+        number=101,
+        title="chore(deps): bump lodash from 4.17.20 to 4.17.21",
+        author="app/dependabot",
+        base_ref="dev",
+        head_sha="a" * 40,
+        files=[
+            ChangedFile(
+                path="package.json",
+                additions=1,
+                deletions=1,
+                patch='@@ -12,7 +12,7 @@\n-    "lodash": "4.17.20"\n+    "lodash": "4.17.21"\n',
+            ),
+            ChangedFile(path="package-lock.json", additions=8, deletions=8, patch=""),
+        ],
+        labels=["dependencies", "javascript"],
+        checks=green_checks(),
+        mergeable="MERGEABLE",
+        merge_state_status="CLEAN",
+        ecosystem="npm",
+    )
+    defaults.update(overrides)
+    return PullRequest(**defaults)
+
+
+def make_baseline(**overrides) -> RepoBaseline:
+    defaults = dict(
+        repo="buffingchi_site",
+        required_contexts=REQUIRED,
+        workflow_file_shas={".github/workflows/ci.yml": "deadbeef"},
+        dependabot_config_sha="cafebabe",
+        thresholds={"cov_fail_under": 80.0},
+    )
+    defaults.update(overrides)
+    return RepoBaseline(**defaults)
+
+
+def workflow_pr(patch: str, **overrides) -> PullRequest:
+    """A github-actions ecosystem PR carrying the supplied workflow diff."""
+    return make_pr(
+        title="chore(deps): bump actions/setup-python from 6 to 7",
+        ecosystem="github-actions",
+        labels=["dependencies", "github_actions"],
+        files=[ChangedFile(path=".github/workflows/ci.yml", additions=1, deletions=1, patch=patch)],
+        **overrides,
+    )
+
+
+@pytest.fixture
+def pr() -> PullRequest:
+    return make_pr()
+
+
+@pytest.fixture
+def baseline() -> RepoBaseline:
+    return make_baseline()

--- a/dependabot-triage/tests/test_execute.py
+++ b/dependabot-triage/tests/test_execute.py
@@ -1,0 +1,391 @@
+"""Tests for the decision loop and the assessment plumbing.
+
+GitHub and the model are both replaced with fakes, so these tests assert what the
+agent *decides* rather than what any external service does. Running with
+``dry_run=True`` keeps the loop deterministic: nothing sleeps, and the drain pass
+exits as soon as it stops making progress.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import REQUIRED, green_checks, make_baseline, make_pr
+
+import assess as assess_mod
+import diagnose as diagnose_mod
+import execute as execute_mod
+from harvest import RepoHarvest
+from llm import ModelResponseInvalid
+from models import Action, Assessment, CheckRun, RiskTier
+
+CONFIG = {
+    "owner": "wcmchenry3-stack",
+    "caps": {"max_merges_per_repo": 5, "max_merges_total": 15},
+    "timeouts": {
+        "rebase_wait": 1200,
+        "checks_wait": 2700,
+        "poll_interval": 0,
+        "global_wall_clock": 14400,
+    },
+    "hold_label": "dependabot-triage:hold",
+    "models": {
+        "assess": "claude-sonnet-5",
+        "adversary": "claude-haiku-4-5",
+        "diagnose": "claude-haiku-4-5",
+        "summary": "claude-haiku-4-5",
+    },
+    "effort": {"assess": "medium", "adversary": "low", "diagnose": "low", "summary": "low"},
+    "budget": {"assessment_token_ceiling": 150000},
+}
+
+
+class FakeClient:
+    """Returns canned responses and records what it was asked."""
+
+    def __init__(
+        self,
+        *,
+        adversary="SAFE — nothing specific found.",
+        assessment=None,
+        diagnosis="Pre-existing failure.\n\nCONFIDENCE: HIGH",
+        tokens=1000,
+    ):
+        self.adversary = adversary
+        self.assessment = assessment or {"assessments": []}
+        self.diagnosis = diagnosis
+        self.tokens = tokens
+        self.calls: list[str] = []
+
+    def count_tokens(self, model, system, prompt):
+        return self.tokens
+
+    def complete(
+        self,
+        *,
+        phase,
+        model,
+        system,
+        prompt,
+        effort="medium",
+        max_tokens=8000,
+        cache_system=False,
+        schema=None,
+    ):
+        self.calls.append(phase)
+        if phase == "assess":
+            return self.assessment, {}
+        if phase == "adversary":
+            return self.adversary, {}
+        if phase.startswith("diagnose"):
+            return self.diagnosis, {}
+        return "Summary.", {}
+
+
+@pytest.fixture(autouse=True)
+def no_github(monkeypatch):
+    """Fail loudly if any test reaches for a real GitHub call."""
+    for name in ("comment", "request_rebase", "merge"):
+        monkeypatch.setattr(execute_mod.gh, name, _record(name))
+    execute_mod.gh._calls = []  # type: ignore[attr-defined]
+    yield
+
+
+def _record(name):
+    def inner(repo, owner, number, *args, **kwargs):
+        execute_mod.gh._calls.append((name, repo, number, kwargs))  # type: ignore[attr-defined]
+
+    return inner
+
+
+def _harvest(prs, *, required=REQUIRED, merge_method="squash") -> RepoHarvest:
+    return RepoHarvest(
+        repo=prs[0].repo if prs else "buffingchi_site",
+        base="dev",
+        merge_method=merge_method,
+        baseline=make_baseline(required_contexts=required),
+        prs=prs,
+    )
+
+
+def _low(pr, order=0, packages=None) -> Assessment:
+    return Assessment(
+        repo=pr.repo,
+        number=pr.number,
+        tier=RiskTier.LOW,
+        merge_order=order,
+        rationale="Patch bump to a build-only dependency.",
+        deciding_question="NONE",
+        packages=packages or [],
+    )
+
+
+def _run(harvests, assessments, client=None):
+    return execute_mod.execute(
+        harvests, assessments, client or FakeClient(), CONFIG, run_url="u", dry_run=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# The merge path
+# ---------------------------------------------------------------------------
+
+
+def test_clean_low_risk_pr_is_merged():
+    pr = make_pr()
+    result = _run([_harvest([pr])], {pr.slug: _low(pr)})
+    assert [d.action for d in result.decisions] == [Action.MERGE]
+    assert result.total_merges == 1
+
+
+def test_medium_risk_pr_is_commented_never_merged():
+    pr = make_pr()
+    assessment = Assessment(
+        pr.repo, pr.number, RiskTier.MEDIUM, 0, "Major version bump.", "Q1_semver"
+    )
+    result = _run([_harvest([pr])], {pr.slug: assessment})
+    assert result.decisions[0].action is Action.COMMENT
+    assert result.total_merges == 0
+    assert result.decisions[0].deciding_question == "Q1_semver"
+
+
+@pytest.mark.parametrize("tier", [RiskTier.MEDIUM, RiskTier.HIGH, RiskTier.BLOCKED])
+def test_only_low_is_ever_eligible_for_merge(tier):
+    pr = make_pr()
+    result = _run([_harvest([pr])], {pr.slug: Assessment(pr.repo, pr.number, tier, 0, "no")})
+    assert result.total_merges == 0
+
+
+def test_guard_failure_overrides_a_low_assessment():
+    """The model saying LOW is never sufficient on its own."""
+    from models import ChangedFile
+
+    pr = make_pr(files=[ChangedFile(path="pytest.ini")])
+    result = _run([_harvest([pr])], {pr.slug: _low(pr)})
+    decision = result.decisions[0]
+    assert decision.action is Action.SKIP
+    assert decision.failed_guard in ("G02", "G03")
+
+
+def test_red_required_check_prevents_merge():
+    checks = green_checks()[:-1] + [CheckRun(name=sorted(REQUIRED)[-1], conclusion="FAILURE")]
+    pr = make_pr(checks=checks)
+    result = _run([_harvest([pr])], {pr.slug: _low(pr)})
+    assert result.decisions[0].action is Action.SKIP
+
+
+def test_repo_without_required_checks_cannot_auto_merge():
+    pr = make_pr()
+    harvest = _harvest([pr], required=frozenset())
+    result = _run([harvest], {pr.slug: _low(pr)})
+    assert result.decisions[0].action is Action.SKIP
+
+
+# ---------------------------------------------------------------------------
+# Adversarial review
+# ---------------------------------------------------------------------------
+
+
+def test_adversary_objection_downgrades_a_low_pr():
+    pr = make_pr()
+    client = FakeClient(adversary="UNSAFE: react-dom is not bumped alongside react")
+    result = _run([_harvest([pr])], {pr.slug: _low(pr)}, client)
+    decision = result.decisions[0]
+    assert decision.action is Action.COMMENT
+    assert decision.tier is RiskTier.MEDIUM
+    assert "react-dom" in decision.reason
+
+
+def test_adversary_runs_on_every_low_pr():
+    prs = [make_pr(number=n) for n in (1, 2, 3)]
+    client = FakeClient()
+    _run([_harvest(prs)], {p.slug: _low(p) for p in prs}, client)
+    assert client.calls.count("adversary") == 3
+
+
+def test_adversary_is_not_consulted_for_non_low_prs():
+    pr = make_pr()
+    client = FakeClient()
+    _run([_harvest([pr])], {pr.slug: Assessment(pr.repo, pr.number, RiskTier.HIGH, 0, "x")}, client)
+    assert "adversary" not in client.calls
+
+
+# ---------------------------------------------------------------------------
+# Rebase handling
+# ---------------------------------------------------------------------------
+
+
+def test_behind_branch_triggers_a_dependabot_rebase_request():
+    pr = make_pr(merge_state_status="BEHIND")
+    _run([_harvest([pr])], {pr.slug: _low(pr)})
+    assert ("request_rebase", pr.repo, pr.number, {"dry_run": True}) in execute_mod.gh._calls
+
+
+def test_a_pr_awaiting_rebase_is_deferred_not_merged():
+    """Nothing is merged while its rebase is still outstanding."""
+    pr = make_pr(merge_state_status="BEHIND")
+    result = _run([_harvest([pr])], {pr.slug: _low(pr)})
+    assert result.total_merges == 0
+    assert result.decisions[0].deferred
+
+
+def test_package_drift_after_rebase_downgrades_to_review():
+    assessment = _low(make_pr(), packages=["lodash@4.17.21"])
+    pr = make_pr(title="bump lodash from 4.17.20 to 4.17.99", merge_state_status="BEHIND")
+    assert execute_mod._packages_drifted(assessment, pr)
+
+
+# ---------------------------------------------------------------------------
+# Caps and ordering
+# ---------------------------------------------------------------------------
+
+
+def test_per_repo_cap_stops_further_merges():
+    config = {**CONFIG, "caps": {"max_merges_per_repo": 2, "max_merges_total": 15}}
+    prs = [make_pr(number=n) for n in range(1, 6)]
+    result = execute_mod.execute(
+        [_harvest(prs)],
+        {p.slug: _low(p) for p in prs},
+        FakeClient(),
+        config,
+        dry_run=True,
+    )
+    assert result.merges_by_repo["buffingchi_site"] == 2
+    assert any(d.deferred for d in result.decisions)
+
+
+def test_total_cap_stops_merges_across_repos():
+    config = {**CONFIG, "caps": {"max_merges_per_repo": 10, "max_merges_total": 3}}
+    harvests = [
+        _harvest([make_pr(repo=repo, number=n) for n in range(1, 4)])
+        for repo in ("BC-Arcade", "buffingchi_site")
+    ]
+    assessments = {p.slug: _low(p) for h in harvests for p in h.prs}
+    result = execute_mod.execute(harvests, assessments, FakeClient(), config, dry_run=True)
+    assert result.total_merges <= 3
+
+
+def test_merge_order_is_respected_within_a_repo():
+    first = make_pr(number=10)
+    second = make_pr(number=20)
+    result = _run(
+        [_harvest([second, first])],
+        {first.slug: _low(first, order=1), second.slug: _low(second, order=2)},
+    )
+    merged = [d.number for d in result.decisions if d.merged]
+    assert merged == [10, 20]
+
+
+def test_hold_label_stops_a_low_pr_from_merging():
+    pr = make_pr(labels=["dependencies", "dependabot-triage:hold"])
+    result = _run([_harvest([pr])], {pr.slug: _low(pr)})
+    assert result.decisions[0].action is Action.SKIP
+
+
+def test_every_decision_produces_a_pr_comment():
+    prs = [make_pr(number=1), make_pr(number=2)]
+    _run([_harvest(prs)], {p.slug: _low(p) for p in prs})
+    commented = {n for name, _, n, _ in execute_mod.gh._calls if name == "comment"}
+    assert commented == {1, 2}
+
+
+# ---------------------------------------------------------------------------
+# assess()
+# ---------------------------------------------------------------------------
+
+
+def test_missing_assessment_defaults_to_medium_not_merge():
+    """A PR the model forgot must never be treated as approved."""
+    pr = make_pr()
+    result = assess_mod.assess([_harvest([pr])], FakeClient(), CONFIG)
+    assert result[pr.slug].tier is RiskTier.MEDIUM
+    assert "No assessment was returned" in result[pr.slug].rationale
+
+
+def test_assessment_is_parsed_into_the_model_type():
+    pr = make_pr()
+    payload = {
+        "assessments": [
+            {
+                "repo": pr.repo,
+                "number": pr.number,
+                "tier": "LOW",
+                "merge_order": 1,
+                "rationale": "Patch bump.",
+                "deciding_question": "NONE",
+                "packages": ["lodash@4.17.21"],
+                "evidence": {},
+            }
+        ]
+    }
+    result = assess_mod.assess([_harvest([pr])], FakeClient(assessment=payload), CONFIG)
+    assert result[pr.slug].tier is RiskTier.LOW
+    assert result[pr.slug].packages == ["lodash@4.17.21"]
+
+
+def test_malformed_assessment_entry_aborts_rather_than_guessing():
+    pr = make_pr()
+    payload = {"assessments": [{"repo": pr.repo, "number": pr.number, "tier": "SORT-OF-FINE"}]}
+    with pytest.raises(ModelResponseInvalid):
+        assess_mod.assess([_harvest([pr])], FakeClient(assessment=payload), CONFIG)
+
+
+def test_no_prs_means_no_model_call_at_all():
+    client = FakeClient()
+    assert assess_mod.assess([_harvest([])], client, CONFIG) == {}
+    assert client.calls == []
+
+
+def test_oversized_corpus_is_assessed_per_repo():
+    prs = [make_pr(number=1)]
+    client = FakeClient(tokens=999_999)
+    assess_mod.assess([_harvest(prs)], client, CONFIG)
+    assert client.calls.count("assess") == 1  # one call per repo, not one giant call
+
+
+def test_corpus_flags_a_repo_with_no_required_checks():
+    pr = make_pr()
+    corpus = assess_mod.build_corpus([_harvest([pr], required=frozenset())])
+    assert "NONE" in corpus and "proves very little" in corpus
+
+
+def test_corpus_marks_main_base_as_deploy_reaching():
+    pr = make_pr(base_ref="main")
+    harvest = _harvest([pr])
+    harvest.base = "main"
+    assert "Render deploy" in assess_mod.build_corpus([harvest])
+
+
+def test_corpus_includes_the_workflow_diff_for_action_bumps():
+    from models import ChangedFile
+
+    patch = "@@\n-        uses: actions/setup-python@v6\n+        uses: actions/setup-python@v7\n"
+    pr = make_pr(
+        ecosystem="github-actions",
+        files=[ChangedFile(path=".github/workflows/ci.yml", patch=patch)],
+    )
+    assert "setup-python@v7" in assess_mod.build_corpus([_harvest([pr])])
+
+
+# ---------------------------------------------------------------------------
+# diagnose()
+# ---------------------------------------------------------------------------
+
+
+def test_diagnosis_is_empty_when_nothing_is_failing():
+    assert diagnose_mod.diagnose(make_pr(), REQUIRED, FakeClient(), CONFIG, dry_run=True) == ""
+
+
+def test_diagnosis_strips_the_confidence_marker():
+    checks = green_checks()[:-1] + [CheckRun(name=sorted(REQUIRED)[-1], conclusion="FAILURE")]
+    text = diagnose_mod.diagnose(
+        make_pr(checks=checks), REQUIRED, FakeClient(), CONFIG, dry_run=True
+    )
+    assert "CONFIDENCE" not in text
+    assert "Pre-existing failure." in text
+
+
+def test_low_confidence_diagnosis_escalates_to_the_stronger_model():
+    checks = green_checks()[:-1] + [CheckRun(name=sorted(REQUIRED)[-1], conclusion="FAILURE")]
+    client = FakeClient(diagnosis="Not sure.\n\nCONFIDENCE: LOW")
+    diagnose_mod.diagnose(make_pr(checks=checks), REQUIRED, client, CONFIG, dry_run=True)
+    assert "diagnose-escalated" in client.calls

--- a/dependabot-triage/tests/test_guards.py
+++ b/dependabot-triage/tests/test_guards.py
@@ -11,8 +11,7 @@ import pytest
 from conftest import REQUIRED, green_checks, make_baseline, make_pr, workflow_pr
 
 import guards
-from models import ChangedFile, CheckRun, RepoBaseline
-
+from models import ChangedFile, CheckRun
 
 # ---------------------------------------------------------------------------
 # Happy path
@@ -93,9 +92,7 @@ def test_rejects_source_and_infra_files(path):
 
 
 def test_a_single_stray_file_fails_an_otherwise_clean_pr(baseline):
-    pr = make_pr(
-        files=[ChangedFile(path="package.json"), ChangedFile(path="src/api/client.ts")]
-    )
+    pr = make_pr(files=[ChangedFile(path="package.json"), ChangedFile(path="src/api/client.ts")])
     results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
     assert not guards.may_merge(results)
 
@@ -135,7 +132,9 @@ def test_pr_that_also_edits_pytest_ini_is_refused(baseline):
     pr = make_pr(
         files=[
             ChangedFile(path="requirements.txt", patch="@@\n-pytest==8.0.0\n+pytest==8.1.0\n"),
-            ChangedFile(path="pytest.ini", patch="@@\n-addopts = --cov-fail-under=80\n+addopts =\n"),
+            ChangedFile(
+                path="pytest.ini", patch="@@\n-addopts = --cov-fail-under=80\n+addopts =\n"
+            ),
         ]
     )
     results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
@@ -248,7 +247,9 @@ def test_forbidden_tokens_inside_generated_lockfiles_are_ignored():
 def test_removed_lines_do_not_trigger_the_scan():
     """Deleting a `continue-on-error` is a strengthening, not a weakening."""
     pr = make_pr(
-        files=[ChangedFile(path=".github/workflows/ci.yml", patch="@@\n-  continue-on-error: true\n")]
+        files=[
+            ChangedFile(path=".github/workflows/ci.yml", patch="@@\n-  continue-on-error: true\n")
+        ]
     )
     assert guards.guard_no_forbidden_patterns(pr).passed
 
@@ -311,7 +312,7 @@ def test_extra_non_required_failures_do_not_block(baseline):
 def test_skipped_and_neutral_count_as_success(baseline):
     checks = [
         CheckRun(name=n, conclusion=c)
-        for n, c in zip(sorted(REQUIRED), ["SUCCESS", "SKIPPED", "NEUTRAL"])
+        for n, c in zip(sorted(REQUIRED), ["SUCCESS", "SKIPPED", "NEUTRAL"], strict=True)
     ]
     assert guards.guard_required_checks_green(make_pr(checks=checks), baseline).passed
 
@@ -419,18 +420,14 @@ def test_extraction_returns_empty_when_nothing_is_configured():
 
 
 def test_workflow_pin_changes_summarises_bumped_actions():
-    patch = (
-        "@@\n-        uses: actions/setup-python@v6\n+        uses: actions/setup-python@v7\n"
-    )
+    patch = "@@\n-        uses: actions/setup-python@v6\n+        uses: actions/setup-python@v7\n"
     assert guards.workflow_pin_changes(workflow_pr(patch).files) == ["actions/setup-python@v7"]
 
 
 def test_workflow_pin_changes_ignores_non_workflow_files():
     files = [
         ChangedFile(path="package.json", patch="@@\n+        uses: not/a-workflow@v1\n"),
-        ChangedFile(
-            path=".github/workflows/ci.yml", patch="@@\n+        uses: actions/cache@v4\n"
-        ),
+        ChangedFile(path=".github/workflows/ci.yml", patch="@@\n+        uses: actions/cache@v4\n"),
     ]
     assert guards.workflow_pin_changes(files) == ["actions/cache@v4"]
 

--- a/dependabot-triage/tests/test_guards.py
+++ b/dependabot-triage/tests/test_guards.py
@@ -1,0 +1,469 @@
+"""Tests for the merge-precondition boundary.
+
+The suite is organised around the question the boundary exists to answer: can a
+pull request that weakens a check reach a merge? Every hostile fixture below is
+a way someone (or something) might try, and each must be refused.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import REQUIRED, green_checks, make_baseline, make_pr, workflow_pr
+
+import guards
+from models import ChangedFile, CheckRun, RepoBaseline
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_clean_patch_bump_passes_every_guard(pr, baseline):
+    results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
+    assert guards.may_merge(results), [str(r) for r in guards.failures(results)]
+
+
+def test_guard_ids_are_unique_and_stable(pr, baseline):
+    results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
+    ids = [r.guard_id for r in results]
+    assert ids == sorted(ids), "guard IDs should be emitted in stable order"
+    assert len(ids) == len(set(ids)), "guard IDs must be unique"
+
+
+# ---------------------------------------------------------------------------
+# G01 — authorship
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("author", ["app/dependabot", "dependabot[bot]", "dependabot"])
+def test_accepts_known_dependabot_identities(author):
+    assert guards.guard_author_is_dependabot(make_pr(author=author)).passed
+
+
+@pytest.mark.parametrize("author", ["wcmchenry3", "app/renovate", "dependabot-preview[bot]", ""])
+def test_rejects_impersonators_and_other_bots(author):
+    result = guards.guard_author_is_dependabot(make_pr(author=author))
+    assert not result.passed
+    assert "not Dependabot" in result.detail
+
+
+def test_impersonator_cannot_merge_even_with_a_perfect_diff(baseline):
+    """The whole point: a human PR shaped like a bump is still out of scope."""
+    pr = make_pr(author="wcmchenry3")
+    results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
+    assert not guards.may_merge(results)
+    assert "G01" in {r.guard_id for r in guards.failures(results)}
+
+
+# ---------------------------------------------------------------------------
+# G02 — path allowlist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "package.json",
+        "frontend/package-lock.json",
+        "backend/requirements.txt",
+        "requirements-dev.txt",
+        "pyproject.toml",
+        "poetry.lock",
+        "ios/Podfile.lock",
+        "go.sum",
+        ".github/workflows/ci.yml",
+        ".github/workflows/deploy.yaml",
+    ],
+)
+def test_allowlist_covers_real_manifest_layouts(path):
+    pr = make_pr(files=[ChangedFile(path=path)])
+    assert guards.guard_paths_allowed(pr).passed, path
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["src/index.js", "backend/app/main.py", "README.md", "Dockerfile", "render.yaml"],
+)
+def test_rejects_source_and_infra_files(path):
+    pr = make_pr(files=[ChangedFile(path=path)])
+    result = guards.guard_paths_allowed(pr)
+    assert not result.passed
+    assert path in result.detail
+
+
+def test_a_single_stray_file_fails_an_otherwise_clean_pr(baseline):
+    pr = make_pr(
+        files=[ChangedFile(path="package.json"), ChangedFile(path="src/api/client.ts")]
+    )
+    results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
+    assert not guards.may_merge(results)
+
+
+# ---------------------------------------------------------------------------
+# G03 — CI-defining files (hostile fixtures from the plan)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "pytest.ini",
+        "setup.cfg",
+        "tox.ini",
+        ".coveragerc",
+        "codecov.yml",
+        ".gitleaks.toml",
+        ".eslintrc.json",
+        "frontend/vitest.config.ts",
+        "jest.config.js",
+        "playwright.config.ts",
+        ".pre-commit-config.yaml",
+        ".github/CODEOWNERS",
+        ".github/dependabot.yml",
+    ],
+)
+def test_denylist_blocks_every_ci_defining_file(path):
+    pr = make_pr(files=[ChangedFile(path=path)])
+    result = guards.guard_no_denylisted_paths(pr)
+    assert not result.passed
+    assert path in result.detail
+
+
+def test_pr_that_also_edits_pytest_ini_is_refused(baseline):
+    """Hostile fixture: a real bump smuggling a test-config change alongside it."""
+    pr = make_pr(
+        files=[
+            ChangedFile(path="requirements.txt", patch="@@\n-pytest==8.0.0\n+pytest==8.1.0\n"),
+            ChangedFile(path="pytest.ini", patch="@@\n-addopts = --cov-fail-under=80\n+addopts =\n"),
+        ]
+    )
+    results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
+    failed = {r.guard_id for r in guards.failures(results)}
+    assert not guards.may_merge(results)
+    assert "G03" in failed
+
+
+# ---------------------------------------------------------------------------
+# G04 — workflow diffs restricted to version pins
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_a_plain_version_pin_bump():
+    patch = (
+        "@@ -20,7 +20,7 @@\n"
+        "-        uses: actions/setup-python@v6\n"
+        "+        uses: actions/setup-python@v7\n"
+    )
+    assert guards.guard_workflow_pins_only(workflow_pr(patch)).passed
+
+
+def test_accepts_sha_pinned_actions_with_trailing_version_comment():
+    patch = (
+        "@@ -8,7 +8,7 @@\n"
+        "-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0\n"
+        "+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2\n"
+    )
+    assert guards.guard_workflow_pins_only(workflow_pr(patch)).passed
+
+
+def test_rejects_a_workflow_diff_that_disables_a_step():
+    """Hostile fixture: the exact 'just turn the check off' move."""
+    patch = (
+        "@@ -30,6 +30,7 @@\n"
+        "-        uses: actions/setup-node@v4\n"
+        "+        uses: actions/setup-node@v5\n"
+        "+        continue-on-error: true\n"
+    )
+    result = guards.guard_workflow_pins_only(workflow_pr(patch))
+    assert not result.passed
+    assert "non-pin changes" in result.detail
+
+
+def test_rejects_a_workflow_diff_that_deletes_a_job():
+    patch = "@@ -40,10 +40,2 @@\n-  cve-frontend:\n-    uses: ./.github/workflows/cve.yml\n"
+    assert not guards.guard_workflow_pins_only(workflow_pr(patch)).passed
+
+
+def test_rejects_workflow_change_with_no_patch_available():
+    """Absent evidence is not evidence of safety."""
+    result = guards.guard_workflow_pins_only(workflow_pr(""))
+    assert not result.passed
+    assert "no patch available" in result.detail
+
+
+def test_ignores_blank_line_churn_in_workflow_diffs():
+    patch = "@@ -20,7 +20,7 @@\n-        uses: actions/cache@v3\n+        uses: actions/cache@v4\n-\n+\n"
+    assert guards.guard_workflow_pins_only(workflow_pr(patch)).passed
+
+
+def test_non_workflow_files_are_not_subject_to_the_pin_rule(pr):
+    assert guards.guard_workflow_pins_only(pr).passed
+
+
+# ---------------------------------------------------------------------------
+# G05 — forbidden patterns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "  continue-on-error: true",
+        "    if: false",
+        "  run: npm audit --audit-level=critical || true",
+        "  run: pytest --cov-fail-under=50",
+        "        fail_ci_if_error: false",
+        "  it.only('renders', () => {})",
+        "  describe.skip('auth', () => {})",
+        "@pytest.mark.skip(reason='flaky')",
+        "@pytest.mark.xfail",
+        "// eslint-disable-next-line no-unused-vars",
+        "value = thing  # type: ignore",
+        "  run: npm ci --legacy-peer-deps",
+        "  run: npm install --force",
+        "  run: SKIP=gitleaks pre-commit run",
+        "  run: git commit --no-verify -m x",
+    ],
+)
+def test_every_check_weakening_token_is_caught(line):
+    pr = make_pr(files=[ChangedFile(path="package.json", patch=f"@@\n+{line}\n")])
+    result = guards.guard_no_forbidden_patterns(pr)
+    assert not result.passed, line
+
+
+def test_forbidden_tokens_inside_generated_lockfiles_are_ignored():
+    """Upstream package metadata is not something this repo authored."""
+    pr = make_pr(
+        files=[
+            ChangedFile(
+                path="package-lock.json",
+                patch='@@\n+      "description": "run with --legacy-peer-deps for old npm"\n',
+            )
+        ]
+    )
+    assert guards.guard_no_forbidden_patterns(pr).passed
+
+
+def test_removed_lines_do_not_trigger_the_scan():
+    """Deleting a `continue-on-error` is a strengthening, not a weakening."""
+    pr = make_pr(
+        files=[ChangedFile(path=".github/workflows/ci.yml", patch="@@\n-  continue-on-error: true\n")]
+    )
+    assert guards.guard_no_forbidden_patterns(pr).passed
+
+
+def test_pr_lowering_coverage_threshold_is_refused(baseline):
+    """Hostile fixture from the plan."""
+    pr = make_pr(
+        files=[
+            ChangedFile(
+                path="pyproject.toml",
+                patch="@@\n-addopts = --cov-fail-under=80\n+addopts = --cov-fail-under=40\n",
+            )
+        ]
+    )
+    results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
+    assert not guards.may_merge(results)
+    assert "G05" in {r.guard_id for r in guards.failures(results)}
+
+
+# ---------------------------------------------------------------------------
+# G06 — required checks
+# ---------------------------------------------------------------------------
+
+
+def test_red_required_check_blocks_merge(baseline):
+    checks = green_checks()[:-1] + [
+        CheckRun(name="secret-scan / Secret scan (gitleaks)", conclusion="FAILURE")
+    ]
+    result = guards.guard_required_checks_green(make_pr(checks=checks), baseline)
+    assert not result.passed
+    assert "secret-scan" in result.detail
+
+
+def test_in_progress_required_check_blocks_merge(baseline):
+    checks = green_checks()[:-1] + [
+        CheckRun(name="secret-scan / Secret scan (gitleaks)", conclusion="", status="IN_PROGRESS")
+    ]
+    assert not guards.guard_required_checks_green(make_pr(checks=checks), baseline).passed
+
+
+def test_missing_required_check_is_treated_as_failing(baseline):
+    """A check that never ran must never read as a passing check."""
+    result = guards.guard_required_checks_green(make_pr(checks=green_checks()[:-1]), baseline)
+    assert not result.passed
+
+
+def test_repo_with_no_required_checks_cannot_auto_merge():
+    """BC-Arcade's `dev` today: green CI proves nothing, so refuse."""
+    empty = make_baseline(required_contexts=frozenset())
+    result = guards.guard_required_checks_green(make_pr(), empty)
+    assert not result.passed
+    assert "proves nothing" in result.detail
+
+
+def test_extra_non_required_failures_do_not_block(baseline):
+    checks = green_checks() + [CheckRun(name="perf (optional)", conclusion="FAILURE")]
+    assert guards.guard_required_checks_green(make_pr(checks=checks), baseline).passed
+
+
+def test_skipped_and_neutral_count_as_success(baseline):
+    checks = [
+        CheckRun(name=n, conclusion=c)
+        for n, c in zip(sorted(REQUIRED), ["SUCCESS", "SKIPPED", "NEUTRAL"])
+    ]
+    assert guards.guard_required_checks_green(make_pr(checks=checks), baseline).passed
+
+
+# ---------------------------------------------------------------------------
+# G07 — branch-protection tamper detection
+# ---------------------------------------------------------------------------
+
+
+def test_removing_a_required_context_mid_run_is_detected(baseline):
+    weakened = frozenset(list(REQUIRED)[:-1])
+    result = guards.guard_protection_unchanged(baseline, weakened)
+    assert not result.passed
+    assert "removed since run start" in result.detail
+
+
+def test_adding_a_required_context_is_allowed(baseline):
+    strengthened = REQUIRED | {"new-check"}
+    assert guards.guard_protection_unchanged(baseline, strengthened).passed
+
+
+# ---------------------------------------------------------------------------
+# G08 — head SHA stability
+# ---------------------------------------------------------------------------
+
+
+def test_head_moving_after_assessment_blocks_merge(pr):
+    assert not guards.guard_head_sha_unchanged(pr, "b" * 40).passed
+
+
+def test_missing_assessed_sha_blocks_merge(pr):
+    assert not guards.guard_head_sha_unchanged(pr, "").passed
+
+
+# ---------------------------------------------------------------------------
+# G09 — threshold ratchet
+# ---------------------------------------------------------------------------
+
+
+def test_lowered_threshold_is_refused(baseline):
+    result = guards.guard_thresholds_not_lowered(baseline, {"cov_fail_under": 60.0})
+    assert not result.passed
+    assert "80.0 -> 60.0" in result.detail
+
+
+@pytest.mark.parametrize("value", [80.0, 85.0])
+def test_holding_or_raising_a_threshold_is_allowed(baseline, value):
+    assert guards.guard_thresholds_not_lowered(baseline, {"cov_fail_under": value}).passed
+
+
+def test_new_threshold_key_is_not_treated_as_a_regression(baseline):
+    assert guards.guard_thresholds_not_lowered(baseline, {"brand_new": 10.0}).passed
+
+
+# ---------------------------------------------------------------------------
+# G10 / G11 — mergeability and kill switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mergeable,state",
+    [("CONFLICTING", "DIRTY"), ("MERGEABLE", "BEHIND"), ("MERGEABLE", "BLOCKED")],
+)
+def test_unmergeable_states_are_refused(mergeable, state):
+    pr = make_pr(mergeable=mergeable, merge_state_status=state)
+    assert not guards.guard_mergeable(pr).passed
+
+
+def test_unstable_is_acceptable_because_required_checks_are_judged_separately():
+    assert guards.guard_mergeable(make_pr(merge_state_status="UNSTABLE")).passed
+
+
+def test_hold_label_stops_a_perfectly_good_pr(baseline):
+    pr = make_pr(labels=["dependencies", "dependabot-triage:hold"])
+    results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
+    assert not guards.may_merge(results)
+    assert "G11" in {r.guard_id for r in guards.failures(results)}
+
+
+# ---------------------------------------------------------------------------
+# Threshold extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_coverage_and_audit_levels_from_ci_config():
+    text = """
+    - run: pytest --cov=. --cov-fail-under=80
+      coverage-threshold: 85
+    - run: npm audit --audit-level=high
+    """
+    found = guards.extract_thresholds(text)
+    assert found["cov_fail_under"] == 80.0
+    assert found["coverage_threshold"] == 85.0
+    assert found["audit_level"] == float(guards.AUDIT_LEVELS.index("high"))
+
+
+def test_strictest_value_wins_when_a_key_appears_twice():
+    """A loosened duplicate later in the file must not mask the stricter one."""
+    found = guards.extract_thresholds("--cov-fail-under=90\n--cov-fail-under=40")
+    assert found["cov_fail_under"] == 90.0
+
+
+def test_extraction_returns_empty_when_nothing_is_configured():
+    assert guards.extract_thresholds("name: CI\non: push\n") == {}
+
+
+def test_workflow_pin_changes_summarises_bumped_actions():
+    patch = (
+        "@@\n-        uses: actions/setup-python@v6\n+        uses: actions/setup-python@v7\n"
+    )
+    assert guards.workflow_pin_changes(workflow_pr(patch).files) == ["actions/setup-python@v7"]
+
+
+def test_workflow_pin_changes_ignores_non_workflow_files():
+    files = [
+        ChangedFile(path="package.json", patch="@@\n+        uses: not/a-workflow@v1\n"),
+        ChangedFile(
+            path=".github/workflows/ci.yml", patch="@@\n+        uses: actions/cache@v4\n"
+        ),
+    ]
+    assert guards.workflow_pin_changes(files) == ["actions/cache@v4"]
+
+
+# ---------------------------------------------------------------------------
+# Path matching helper
+# ---------------------------------------------------------------------------
+
+
+def test_double_star_pattern_also_matches_at_the_repository_root():
+    """`**/x` must cover a root-level `x`, so monorepo and flat layouts share one rule."""
+    assert guards._matches_any("Podfile.lock", ("**/Podfile.lock",))
+    assert guards._matches_any("ios/Podfile.lock", ("**/Podfile.lock",))
+    assert not guards._matches_any("Podfile", ("**/Podfile.lock",))
+
+
+# ---------------------------------------------------------------------------
+# Aggregate behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_guards_reports_every_failure_not_just_the_first(baseline):
+    pr = make_pr(
+        author="someone-else",
+        labels=["dependabot-triage:hold"],
+        files=[ChangedFile(path="src/main.py")],
+        merge_state_status="BEHIND",
+    )
+    failed = {r.guard_id for r in guards.failures(guards.run_all_guards(pr, baseline, "x" * 40))}
+    assert {"G01", "G02", "G08", "G10", "G11"} <= failed
+
+
+def test_baseline_thresholds_are_used_when_current_not_supplied(pr, baseline):
+    """Omitting live thresholds must not silently pass the ratchet check."""
+    results = guards.run_all_guards(pr, baseline, assessed_sha=pr.head_sha)
+    assert next(r for r in results if r.guard_id == "G09").passed

--- a/dependabot-triage/tests/test_guards.py
+++ b/dependabot-triage/tests/test_guards.py
@@ -424,6 +424,19 @@ def test_workflow_pin_changes_summarises_bumped_actions():
     assert guards.workflow_pin_changes(workflow_pr(patch).files) == ["actions/setup-python@v7"]
 
 
+def test_workflow_pin_changes_deduplicates_an_action_pinned_in_several_jobs():
+    """RulersAI#663 bumps setup-python in two jobs; the comment should say it once."""
+    patch = (
+        "@@ -20,7 +20,7 @@\n"
+        "-        uses: actions/setup-python@v6\n"
+        "+        uses: actions/setup-python@v7\n"
+        "@@ -55,7 +55,7 @@\n"
+        "-        uses: actions/setup-python@v6\n"
+        "+        uses: actions/setup-python@v7\n"
+    )
+    assert guards.workflow_pin_changes(workflow_pr(patch).files) == ["actions/setup-python@v7"]
+
+
 def test_workflow_pin_changes_ignores_non_workflow_files():
     files = [
         ChangedFile(path="package.json", patch="@@\n+        uses: not/a-workflow@v1\n"),

--- a/dependabot-triage/tests/test_pipeline.py
+++ b/dependabot-triage/tests/test_pipeline.py
@@ -1,0 +1,460 @@
+"""Tests for the phases around the guard boundary.
+
+Nothing here reaches the network. The pieces that would — GitHub calls and model
+calls — are isolated behind :mod:`gh` and :mod:`llm`, so everything below is a
+pure function over fixtures.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from conftest import make_pr
+
+import budget as budget_mod
+import execute as execute_mod
+import harvest as harvest_mod
+import metrics as metrics_mod
+import report as report_mod
+from models import Action, Assessment, Decision, GuardResult, RiskTier
+
+NOW = datetime(2026, 8, 15, 6, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# harvest — diff splitting and title parsing
+# ---------------------------------------------------------------------------
+
+MULTI_FILE_DIFF = """diff --git a/package.json b/package.json
+index 111..222 100644
+--- a/package.json
++++ b/package.json
+@@ -10,7 +10,7 @@
+-    "vite": "5.0.0"
++    "vite": "5.1.0"
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 333..444 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -5,7 +5,7 @@
+-        uses: actions/checkout@v4
++        uses: actions/checkout@v5
+"""
+
+
+def test_split_diff_separates_each_file():
+    patches = harvest_mod.split_diff(MULTI_FILE_DIFF)
+    assert set(patches) == {"package.json", ".github/workflows/ci.yml"}
+    assert '+    "vite": "5.1.0"' in patches["package.json"]
+    assert "actions/checkout@v5" in patches[".github/workflows/ci.yml"]
+    assert "vite" not in patches[".github/workflows/ci.yml"]
+
+
+def test_split_diff_uses_the_destination_path_for_renames():
+    diff = "diff --git a/old.txt b/new.txt\n@@\n+x\n"
+    assert set(harvest_mod.split_diff(diff)) == {"new.txt"}
+
+
+def test_split_diff_of_empty_input_is_empty():
+    assert harvest_mod.split_diff("") == {}
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [
+        ("chore(deps): bump lodash from 4.17.20 to 4.17.21", ("lodash", "4.17.20", "4.17.21")),
+        ("Bump actions/setup-python from 6 to 7", ("actions/setup-python", "6", "7")),
+        ("chore(deps-dev): bump vite from 5.0.0 to 6.0.0", ("vite", "5.0.0", "6.0.0")),
+        ("Update the expo group", ("", "", "")),
+    ],
+)
+def test_parse_bump_handles_dependabot_title_formats(title, expected):
+    assert harvest_mod.parse_bump(title) == expected
+
+
+@pytest.mark.parametrize(
+    "labels,paths,expected",
+    [
+        (["javascript"], [], "npm"),
+        (["python"], [], "pip"),
+        (["github_actions"], [], "github-actions"),
+        ([], [".github/workflows/ci.yml"], "github-actions"),
+        ([], ["frontend/package.json"], "npm"),
+        ([], ["backend/requirements.txt"], "pip"),
+        ([], ["something/else"], "unknown"),
+    ],
+)
+def test_ecosystem_detection_prefers_labels_then_paths(labels, paths, expected):
+    assert harvest_mod.detect_ecosystem(labels, paths) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,conclusion,status",
+    [
+        ({"bucket": "pass", "state": "SUCCESS"}, "SUCCESS", "COMPLETED"),
+        ({"bucket": "fail", "state": "FAILURE"}, "FAILURE", "COMPLETED"),
+        ({"bucket": "skipping", "state": ""}, "SKIPPED", "COMPLETED"),
+        ({"bucket": "pending", "state": ""}, "", "IN_PROGRESS"),
+    ],
+)
+def test_check_buckets_map_onto_the_checkrun_vocabulary(raw, conclusion, status):
+    assert harvest_mod._bucket_to_conclusion(raw) == (conclusion, status)
+
+
+# ---------------------------------------------------------------------------
+# budget — pricing and ceilings
+# ---------------------------------------------------------------------------
+
+
+def test_price_uses_published_rates():
+    spend = budget_mod.price(
+        "claude-sonnet-5", {"input_tokens": 1_000_000, "output_tokens": 1_000_000}
+    )
+    assert spend.usd == pytest.approx(3.00 + 15.00)
+
+
+def test_cache_reads_are_charged_at_a_tenth_of_input():
+    spend = budget_mod.price("claude-sonnet-5", {"cache_read_input_tokens": 1_000_000})
+    assert spend.usd == pytest.approx(0.30)
+
+
+def test_cache_writes_carry_a_premium():
+    spend = budget_mod.price("claude-sonnet-5", {"cache_creation_input_tokens": 1_000_000})
+    assert spend.usd == pytest.approx(3.75)
+
+
+def test_unknown_model_is_charged_at_the_highest_rate_not_zero():
+    """A model-id typo must be alarming, not free."""
+    spend = budget_mod.price("claude-typo-9", {"input_tokens": 1_000_000})
+    assert spend.usd > 0
+
+
+def test_per_run_ceiling_stops_further_calls():
+    b = budget_mod.Budget(max_per_run=0.01)
+    b.record("assess", "claude-sonnet-5", {"input_tokens": 1_000_000})
+    with pytest.raises(budget_mod.BudgetExceeded, match="per-run"):
+        b.check_before_call()
+
+
+def test_monthly_ceiling_accounts_for_prior_runs():
+    b = budget_mod.Budget(max_per_run=100.0, max_per_month=5.0, month_to_date=4.99)
+    b.record("assess", "claude-haiku-4-5", {"input_tokens": 100_000})
+    with pytest.raises(budget_mod.BudgetExceeded, match="monthly"):
+        b.check_before_call()
+
+
+def test_budget_under_both_ceilings_permits_the_call():
+    b = budget_mod.Budget(max_per_run=1.0, max_per_month=20.0)
+    b.record("assess", "claude-haiku-4-5", {"input_tokens": 1000})
+    b.check_before_call()  # must not raise
+
+
+def test_spend_is_attributed_per_phase():
+    b = budget_mod.Budget()
+    b.record("assess", "claude-sonnet-5", {"input_tokens": 1000})
+    b.record("adversary", "claude-haiku-4-5", {"input_tokens": 1000})
+    b.record("adversary", "claude-haiku-4-5", {"input_tokens": 1000})
+    summary = b.summary()
+    assert summary["by_phase"]["adversary"]["calls"] == 2
+    assert summary["calls"] == 3
+
+
+def test_should_chunk_only_above_the_ceiling():
+    assert budget_mod.should_chunk(150_001, 150_000)
+    assert not budget_mod.should_chunk(150_000, 150_000)
+
+
+# ---------------------------------------------------------------------------
+# metrics
+# ---------------------------------------------------------------------------
+
+
+def _decision(**kw) -> Decision:
+    defaults = {
+        "repo": "BC-Arcade",
+        "number": 1,
+        "title": "bump x",
+        "tier": RiskTier.LOW,
+        "action": Action.MERGE,
+        "reason": "ok",
+        "merged": True,
+    }
+    defaults.update(kw)
+    return Decision(**defaults)
+
+
+def test_autonomy_rate_is_merged_over_eligible():
+    decisions = [
+        _decision(number=1),
+        _decision(number=2),
+        _decision(number=3, tier=RiskTier.HIGH, action=Action.COMMENT, merged=False),
+    ]
+    # Rates are stored rounded to 4 dp; they are displayed as whole percentages.
+    assert metrics_mod.summarise(decisions)["autonomy_rate"] == pytest.approx(2 / 3, abs=1e-4)
+
+
+def test_deferred_prs_do_not_count_against_the_autonomy_rate():
+    """Work the agent never got to is not work it declined to do."""
+    decisions = [
+        _decision(number=1),
+        _decision(number=2, action=Action.COMMENT, merged=False, deferred=True),
+    ]
+    stats = metrics_mod.summarise(decisions)
+    assert stats["eligible"] == 1
+    assert stats["autonomy_rate"] == 1.0
+
+
+def test_summarise_attributes_skips_to_the_rubric_question():
+    decisions = [
+        _decision(
+            number=1,
+            tier=RiskTier.HIGH,
+            action=Action.COMMENT,
+            merged=False,
+            deciding_question="Q5_peer_coupling",
+        ),
+        _decision(
+            number=2,
+            tier=RiskTier.HIGH,
+            action=Action.COMMENT,
+            merged=False,
+            deciding_question="Q5_peer_coupling",
+        ),
+        _decision(
+            number=3,
+            tier=RiskTier.MEDIUM,
+            action=Action.COMMENT,
+            merged=False,
+            deciding_question="Q1_semver",
+        ),
+    ]
+    counts = metrics_mod.summarise(decisions)["by_deciding_question"]
+    assert counts == {"Q5_peer_coupling": 2, "Q1_semver": 1}
+
+
+def test_summarise_attributes_refusals_to_the_guard_that_fired():
+    decision = _decision(
+        action=Action.SKIP,
+        merged=False,
+        guard_results=[
+            GuardResult("G01", True, ""),
+            GuardResult("G03", False, "touches pytest.ini"),
+        ],
+    )
+    assert metrics_mod.summarise([decision])["by_failed_guard"] == {"G03": 1}
+
+
+def test_summarise_of_an_empty_run_reports_no_rate():
+    stats = metrics_mod.summarise([])
+    assert stats["seen"] == 0
+    assert stats["autonomy_rate"] is None
+
+
+def test_history_round_trips_through_disk(tmp_path, monkeypatch):
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    metrics_mod.record_run([_decision()], {"run_usd": 0.22}, run_id="r1", now=NOW, dry_run=False)
+    entries = metrics_mod.load_history()
+    assert [e["type"] for e in entries] == ["decision", "run"]
+    assert entries[1]["budget"]["run_usd"] == 0.22
+
+
+def test_rolling_window_excludes_dry_runs(tmp_path, monkeypatch):
+    """A dry run describes what would have happened; counting it overstates the rate."""
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    metrics_mod.record_run([_decision()], {}, run_id="dry", now=NOW, dry_run=True)
+    assert metrics_mod.rolling(now=NOW + timedelta(hours=1))["decisions"] == 0
+
+    metrics_mod.record_run([_decision(number=2)], {}, run_id="live", now=NOW, dry_run=False)
+    assert metrics_mod.rolling(now=NOW + timedelta(hours=1))["decisions"] == 1
+
+
+def test_rolling_window_excludes_entries_older_than_the_window(tmp_path, monkeypatch):
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    metrics_mod.record_run(
+        [_decision()], {}, run_id="old", now=NOW - timedelta(days=60), dry_run=False
+    )
+    assert metrics_mod.rolling(days=30, now=NOW)["decisions"] == 0
+
+
+def test_precision_falls_when_a_regression_is_recorded(tmp_path, monkeypatch):
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    metrics_mod.record_run(
+        [_decision(number=n) for n in (1, 2, 3, 4)], {}, run_id="r", now=NOW, dry_run=False
+    )
+    assert metrics_mod.precision(now=NOW + timedelta(hours=1))["precision"] == 1.0
+
+    metrics_mod.record_regression("BC-Arcade", 1, "r", "base branch went red", NOW)
+    assert metrics_mod.precision(now=NOW + timedelta(hours=1))["precision"] == 0.75
+
+
+def test_month_to_date_spend_sums_live_runs_only(tmp_path, monkeypatch):
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    metrics_mod.record_run([], {"run_usd": 0.20}, run_id="a", now=NOW, dry_run=False)
+    metrics_mod.record_run([], {"run_usd": 0.30}, run_id="b", now=NOW, dry_run=False)
+    metrics_mod.record_run([], {"run_usd": 9.99}, run_id="c", now=NOW, dry_run=True)
+    assert metrics_mod.month_to_date_spend(NOW) == pytest.approx(0.50)
+
+
+def test_malformed_history_lines_are_skipped_not_fatal(tmp_path, monkeypatch):
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    (tmp_path / "2026-08.jsonl").write_text('{"type":"run"}\nnot json\n', encoding="utf-8")
+    assert len(metrics_mod.load_history()) == 1
+
+
+# ---------------------------------------------------------------------------
+# execute — helpers that decide comment text and drift
+# ---------------------------------------------------------------------------
+
+
+def test_merge_comment_states_the_agent_cannot_edit_files():
+    body = execute_mod._comment_body(_decision(), "https://example/run/1")
+    assert "Merged automatically" in body
+    assert "never edits a file" not in body  # wording lives in the email
+    assert "may only comment" in body
+
+
+def test_refusal_comment_names_every_failed_guard():
+    decision = _decision(
+        action=Action.SKIP,
+        merged=False,
+        guard_results=[
+            GuardResult("G03", False, "touches pytest.ini"),
+            GuardResult("G06", False, "required checks not green"),
+        ],
+    )
+    body = execute_mod._comment_body(decision, "https://example/run/1")
+    assert "`G03`" in body and "`G06`" in body
+    assert "touches pytest.ini" in body
+
+
+def test_comment_includes_the_deciding_rubric_question():
+    decision = _decision(action=Action.COMMENT, merged=False, deciding_question="Q5_peer_coupling")
+    assert "Q5_peer_coupling" in execute_mod._comment_body(decision, "")
+
+
+def test_package_drift_detected_when_rebase_changes_the_target_version():
+    assessment = Assessment("r", 1, RiskTier.LOW, 0, "", packages=["lodash@4.17.21"])
+    same = make_pr(title="bump lodash from 4.17.20 to 4.17.21")
+    moved = make_pr(title="bump lodash from 4.17.20 to 4.17.22")
+    assert not execute_mod._packages_drifted(assessment, same)
+    assert execute_mod._packages_drifted(assessment, moved)
+
+
+def test_no_drift_reported_when_the_assessment_listed_no_packages():
+    assessment = Assessment("r", 1, RiskTier.LOW, 0, "", packages=[])
+    assert not execute_mod._packages_drifted(assessment, make_pr())
+
+
+def test_checks_settled_requires_every_required_context():
+    from conftest import REQUIRED, green_checks
+
+    from models import CheckRun
+
+    assert execute_mod._checks_settled(make_pr(checks=green_checks()), REQUIRED)
+
+    running = green_checks()[:-1] + [
+        CheckRun(name=sorted(REQUIRED)[-1], conclusion="", status="IN_PROGRESS")
+    ]
+    assert not execute_mod._checks_settled(make_pr(checks=running), REQUIRED)
+
+
+# ---------------------------------------------------------------------------
+# report — rendering is deterministic
+# ---------------------------------------------------------------------------
+
+
+def _render(decisions, **kw):
+    defaults = {
+        "summary": "Summary text.",
+        "decisions": decisions,
+        "stats": metrics_mod.summarise(decisions),
+        "rolling": {"window_days": 30, "autonomy_rate": 0.71},
+        "precision": {"precision": 1.0},
+        "budget": {"run_usd": 0.22, "month_usd": 4.8, "max_per_month": 20.0},
+        "run_url": "https://example/run/1",
+        "when": NOW,
+        "dry_run": False,
+    }
+    defaults.update(kw)
+    return report_mod.render_html(**defaults)
+
+
+def test_email_groups_every_repo_into_one_message():
+    """The whole stack lands in a single email, not one per repo."""
+    decisions = [
+        _decision(repo="BC-Arcade", number=1),
+        _decision(repo="buffingchi_site", number=2),
+        _decision(repo="RulersAI", number=3, action=Action.COMMENT, merged=False),
+    ]
+    body = _render(decisions)
+    for repo in ("BC-Arcade", "buffingchi_site", "RulersAI"):
+        assert repo in body
+
+
+def test_email_shows_autonomy_rate_and_precision():
+    body = _render([_decision()])
+    assert "71%" in body
+    assert "100%" in body
+
+
+def test_dry_run_is_labelled_so_it_cannot_be_mistaken_for_a_live_run():
+    assert "Dry run" in _render([_decision()], dry_run=True)
+
+
+def test_aborted_run_leads_with_the_abort_banner():
+    body = _render([], aborted="monthly ceiling reached")
+    assert "Run aborted" in body
+    assert "monthly ceiling reached" in body
+
+
+def test_titles_are_html_escaped():
+    body = _render([_decision(title="<script>alert(1)</script>")])
+    assert "<script>" not in body
+    assert "&lt;script&gt;" in body
+
+
+def test_empty_run_renders_without_error():
+    assert "No open Dependabot pull requests" in _render([])
+
+
+def test_subject_line_summarises_the_night():
+    stats = metrics_mod.summarise(
+        [_decision(), _decision(number=2, merged=False, action=Action.COMMENT)]
+    )
+    config = {"report": {"subject_prefix": "Dependabot Triage"}}
+    assert report_mod.subject_line(stats, config, NOW) == (
+        "Dependabot Triage — 1 merged, 1 pending — Sat 15 Aug"
+    )
+
+
+def test_aborted_subject_is_unmistakable():
+    config = {"report": {"subject_prefix": "Dependabot Triage"}}
+    subject = report_mod.subject_line({"merged": 0, "seen": 0}, config, NOW, aborted="budget")
+    assert "ABORTED" in subject
+
+
+def test_summary_falls_back_when_no_client_is_available():
+    assert report_mod.compose_summary({}, None, {}) == "Nightly Dependabot triage completed."
+
+
+def test_summary_reports_the_abort_reason_without_calling_a_model():
+    text = report_mod.compose_summary({}, None, {}, aborted="tamper tripwire fired")
+    assert "tamper tripwire fired" in text
+    assert "Nothing further was merged" in text
+
+
+def test_send_is_a_noop_during_a_dry_run():
+    config = {"report": {"from_address": "a@b.c", "to_address": "d@e.f"}}
+    assert report_mod.send("<p>x</p>", "subject", config, dry_run=True) is False
+
+
+def test_ledger_shape_is_json_serialisable():
+    decisions = [_decision(guard_results=[GuardResult("G01", True, "ok")])]
+    payload = {
+        "decisions": [
+            {"repo": d.repo, "number": d.number, "action": d.action.value} for d in decisions
+        ]
+    }
+    assert json.loads(json.dumps(payload))["decisions"][0]["action"] == "MERGE"


### PR DESCRIPTION
## Summary

A scheduled job that clears the low-risk Dependabot queue overnight, refuses anything it cannot justify, and sends one email covering every repo.

Context: ~83 Dependabot merges/month across the stack, and BC-Arcade's CI runs 20–30 minutes, so the merge → rebase → wait → merge cycle is the real bottleneck.

**The agent has exactly three side effects: comment, ask Dependabot to rebase, and merge.** It never edits a file and never pushes a commit — rebases are performed by Dependabot in response to a comment. That is the load-bearing safeguard: there is no code path from here to "disable the failing check", and the token carries no `Administration` or `Actions` permission to reach for one either.

## What's here

| Phase | Module | Model |
|---|---|---|
| Harvest PRs + tamper baseline | `harvest.py` | none |
| Collective risk assessment (14-question rubric, whole stack in one call) | `assess.py` | Sonnet 5 |
| Decide, rebase, merge | `execute.py` | none |
| Diagnose failing checks | `diagnose.py` | Haiku 4.5 |
| One stack-wide email | `report.py` | Haiku 4.5 (summary paragraph only) |
| Persistent history | `metrics.py` | none |

The model classifies; deterministic code decides. Phase 2 returns schema-validated data, and phase 3 maps it onto a four-value action vocabulary — a model response can never be read as a command.

## Safeguards

Eleven guards (`G01`–`G11`) re-run against freshly fetched API state immediately before every merge: Dependabot authorship, path allowlist, CI-config denylist, workflow diffs restricted to `uses:` version pins, a forbidden-pattern scan, required checks green, branch-protection tamper detection, head-SHA stability, a threshold ratchet, mergeability, and a hold label.

On top of that: an adversarial second opinion on every `LOW` (a *different, weaker* model arguing the merge is unsafe, so it isn't the same reasoning agreeing with itself), per-repo and total merge caps, spend ceilings, and a tripwire that aborts the run if any baseline drifts mid-flight.

## Verification done

- **179 tests, 85% overall coverage, 100% on `guards.py`.** The workflow re-verifies that 100% before the agent is allowed to run.
- Hostile fixtures all refused: a PR that also edits `pytest.ini`, one that lowers `--cov-fail-under`, one adding `continue-on-error`, one impersonating Dependabot, one whose workflow hunk changes something other than a version pin.
- **Live dry run against `RulersAI#663`** (the one open Dependabot PR in the org). It correctly parsed the workflow diff, detected the ecosystem, captured all 15 checks — and refused the merge on `G06`, because RulersAI's `dev` branch declares **zero required status checks**, so a green PR proves nothing there. That refusal is the designed behaviour and it caught a real config gap. The run also surfaced two bugs, both fixed in b57c6a6.

## Not enabled yet

`config.yml` ships with only `powerplayshistory_site` enabled (5 merges/month, no production traffic) and `--dry-run` as the default everywhere including the workflow. Going live is an explicit `workflow_dispatch` choice.

## Test plan

- [ ] Review the 14-question risk rubric in `prompts/assess.md` — that's the judgment this delegates
- [ ] Review the guard allowlist/denylist in `guards.py` for anything missing for your repos
- [ ] Add secrets: `ANTHROPIC_API_KEY`, `RESEND_API_KEY`, `DEPENDABOT_TRIAGE_TOKEN`
- [ ] `workflow_dispatch` with `dry_run: true` and confirm the email covers all repos in one message
- [ ] Budget drill: set `max_per_run: 0.01` and confirm the run aborts and emails red

## Follow-ups (not in this PR)

- **Phase 0 config work** — `strict: true` on `buffingchi_site`/`BookshelfAI` `dev` is what forces the serial rebase chain; catch-all Dependabot grouping would collapse BC-Arcade's ~38 PRs/month to ~5. Both cut the volume more than this agent does.
- BC-Arcade and RulersAI `dev` have no required status checks.
- `called-claude-failure-analysis.yml` references `claude-sonnet-4-5-20241022`, which is not a valid model ID, and has never run because no repo had `ANTHROPIC_API_KEY`.
- Global hard rule #9 needs the narrow Dependabot carve-out this PR assumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn