### PR TITLE
fix(ci): repair the ZAP workflow and correct an invalid Claude model id

### DIFF
--- a/.github/workflows/called-claude-failure-analysis.yml
+++ b/.github/workflows/called-claude-failure-analysis.yml
@@ -58,7 +58,7 @@ jobs:
             -H "anthropic-version: 2023-06-01" \
             -H "content-type: application/json" \
             -d "{
-              \"model\": \"claude-sonnet-4-5-20241022\",
+              \"model\": \"claude-sonnet-5\",
               \"max_tokens\": 1024,
               \"messages\": [{
                 \"role\": \"user\",

--- a/.github/workflows/called-zap-scheduled.yml
+++ b/.github/workflows/called-zap-scheduled.yml
@@ -29,6 +29,12 @@ jobs:
     permissions:
       issues: write
       contents: read
+    env:
+      # The `secrets` context is not available in step-level `if:` conditions,
+      # so the target is resolved once here and the steps below branch on `env`,
+      # which is available. Bracket syntax is required because the secret name
+      # contains hyphens and cannot be reached with dot notation.
+      ZAP_TARGET: ${{ secrets['target-url-secret'] || inputs.target-url }}
     steps:
       - uses: actions/checkout@v4
       - name: Guard - branch filter
@@ -45,13 +51,13 @@ jobs:
             echo "Skipping ZAP scan: branch '$CURRENT' not in [$BRANCHES]"
           fi
       - name: Run ZAP baseline scan
-        if: ${{ steps.guard.outputs.run == 'true' && (secrets.target-url-secret != '' || inputs.target-url != '') }}
+        if: ${{ steps.guard.outputs.run == 'true' && env.ZAP_TARGET != '' }}
         uses: zaproxy/action-baseline@v0.15.0
         with:
-          target: ${{ secrets.target-url-secret || inputs.target-url }}
+          target: ${{ env.ZAP_TARGET }}
           fail_action: false
       - name: Upload ZAP report
-        if: ${{ steps.guard.outputs.run == 'true' && (secrets.target-url-secret != '' || inputs.target-url != '') }}
+        if: ${{ steps.guard.outputs.run == 'true' && env.ZAP_TARGET != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary

Two long-standing bugs found while auditing CI. Neither is caused by the Dependabot triage work, and both predate it by months.

### 1. `called-zap-scheduled.yml` has never been runnable

It produces a 0-second **"This run likely failed because of a workflow file issue"** on every push, including on `main`, going back to at least July 2026.

Two step-level `if:` conditions did this:

```yaml
if: ${{ steps.guard.outputs.run == 'true' && (secrets.target-url-secret != '' || inputs.target-url != '') }}
```

Two separate problems in one line:

- **`secrets` is not available in a step-level `if:`.** GitHub does not expose that context there, so the expression is invalid.
- **`secrets.target-url-secret` uses dot notation on a hyphenated name.** Expression syntax requires `secrets['target-url-secret']` for names that are not valid identifiers.

GitHub rejects the file at registration, which means **this workflow could never have run for any caller** — every repo calling it was getting no ZAP scan at all, silently.

Fixed by resolving the target once into a job-level `env` (where `secrets` *is* available) and branching on `env` in the steps.

### 2. `called-claude-failure-analysis.yml` used a model id that does not exist

`claude-sonnet-4-5-20241022` — that date belongs to Sonnet 3.5; Sonnet 4.5 was `20250929`. Now `claude-sonnet-5`.

This workflow has also never actually run, because no repo in the org has an `ANTHROPIC_API_KEY` secret. Adding that is a separate manual step and is not part of this PR.

### Also checked

Grepped every workflow for the same `secrets`-in-`if:` mistake. There are no others.

## Test plan

- [ ] After merge, confirm pushes no longer produce a failed `called-zap-scheduled.yml` run
- [ ] Trigger a caller of the ZAP workflow (e.g. a deploy) and confirm the scan step actually executes when a target is supplied
- [ ] Confirm the guard still skips cleanly when no target is supplied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn