### PR TITLE
fix(dependabot-triage): fail loudly when branch protection cannot be read

### DIFF
--- a/dependabot-triage/README.md
+++ b/dependabot-triage/README.md
@@ -94,7 +94,7 @@ staged-rollout starting point.
 |---|---|
 | `ANTHROPIC_API_KEY` | Model calls. Pay-as-you-go API billing, deliberately separate from any Claude Code subscription — this job cannot consume interactive usage. |
 | `RESEND_API_KEY` | The nightly email. One message a day sits far inside Resend's free tier. |
-| `DEPENDABOT_TRIAGE_TOKEN` | Cross-repo PR access. Fine-grained, `Pull requests: RW` + `Contents: RW` + `Metadata: R`, and deliberately **no** `Administration` or `Actions`. |
+| `DEPENDABOT_TRIAGE_TOKEN` | Cross-repo PR access. Fine-grained: `Pull requests: RW`, `Contents: RW`, `Metadata: R`, and `Administration: **Read**` — required to read which status checks a branch mandates. Read-only is the point: the agent must be able to *see* branch protection to enforce G06 and G07, and must never be able to *change* it. Deliberately **no** `Actions`, no `Administration: Write`. |
 
 The workflow's own `GITHUB_TOKEN` commits the metrics history and is scoped to
 this repository only, so the two credentials stay separate.

--- a/dependabot-triage/__main__.py
+++ b/dependabot-triage/__main__.py
@@ -106,12 +106,63 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     # --- Phase 1 ---------------------------------------------------------
-    harvests = harvest_mod.harvest_all(config)
+    # A permission gap here must not look like a quiet night. Reading branch
+    # protection needs 'Administration: Read'; without it the API's refusal is
+    # easy to mistake for "no checks are required", which would make the agent
+    # silently refuse every PR while appearing to work.
+    try:
+        harvests = harvest_mod.harvest_all(config)
+    except gh.ProtectionUnreadable as exc:
+        log.error("%s", exc)
+        stats = metrics.summarise([])
+        body = report_mod.render_html(
+            summary="",
+            decisions=[],
+            stats=stats,
+            rolling=metrics.rolling(now=now),
+            precision=metrics.precision(now=now),
+            budget=budget.summary(),
+            run_url=args.run_url,
+            when=now,
+            dry_run=args.dry_run,
+            aborted=str(exc),
+        )
+        report_mod.send(
+            body,
+            report_mod.subject_line(stats, config, now, aborted=str(exc)),
+            config,
+            dry_run=args.dry_run,
+        )
+        return 1
+
     open_prs = [pr for h in harvests for pr in h.dependabot_prs]
 
     if not open_prs:
         log.info("no open Dependabot PRs; exiting before any model call")
         stats = metrics.summarise([])
+        # Write the ledger even on the quiet path, so "no artifact" always means
+        # the job died rather than "there was nothing to do".
+        args.ledger.parent.mkdir(parents=True, exist_ok=True)
+        args.ledger.write_text(
+            json.dumps(
+                {
+                    "run_id": args.run_id,
+                    "at": now.isoformat(),
+                    "dry_run": args.dry_run,
+                    "aborted": "",
+                    "stats": stats,
+                    "budget": budget.summary(),
+                    "decisions": [],
+                    "repos_checked": [
+                        {"repo": h.repo, "required_checks": sorted(h.baseline.required_contexts)}
+                        for h in harvests
+                    ],
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
         body = report_mod.render_html(
             summary="No open Dependabot pull requests tonight; nothing to do.",
             decisions=[],

--- a/dependabot-triage/gh.py
+++ b/dependabot-triage/gh.py
@@ -23,6 +23,33 @@ class GhError(RuntimeError):
     """A ``gh`` invocation failed."""
 
 
+class ProtectionUnreadable(GhError):
+    """Branch protection exists but this token is not allowed to read it.
+
+    Reading branch protection requires ``Administration: Read``. Without it the
+    API answers with a permission error that is easy to mistake for "this branch
+    has no protection" — and that mistake is dangerous in both directions: it
+    makes a protected repo look unprotected, and it makes a token-permission
+    problem look like a repo-configuration problem. The run aborts instead.
+    """
+
+
+# Substrings GitHub uses when a token lacks the permission, as opposed to when
+# the resource genuinely does not exist.
+_PERMISSION_MARKERS = (
+    "resource not accessible",
+    "must have admin rights",
+    "not accessible by integration",
+    "requires authentication",
+    "403",
+)
+
+
+def _is_permission_error(exc: GhError) -> bool:
+    text = str(exc).lower()
+    return any(marker in text for marker in _PERMISSION_MARKERS)
+
+
 def _run(args: list[str], *, timeout: int = 120) -> str:
     """Execute ``gh`` with an argument list and return stdout."""
     log.debug("gh %s", " ".join(args))
@@ -119,6 +146,10 @@ def required_contexts(repo: str, owner: str, branch: str) -> frozenset[str]:
 
     Repos in this org use both mechanisms, and a repo may have neither — in which
     case the empty set is returned and guard G06 refuses to auto-merge there.
+
+    Raises :class:`ProtectionUnreadable` when the token lacks permission to read
+    protection. An empty result must only ever mean "nothing is required here",
+    never "I was not allowed to look".
     """
     contexts: set[str] = set()
     try:
@@ -128,7 +159,13 @@ def required_contexts(repo: str, owner: str, branch: str) -> frozenset[str]:
         for entry in checks.get("checks") or []:
             if entry.get("context"):
                 contexts.add(entry["context"])
-    except GhError:
+    except GhError as exc:
+        if _is_permission_error(exc):
+            raise ProtectionUnreadable(
+                f"cannot read branch protection for {owner}/{repo}@{branch}. "
+                "The token needs 'Administration: Read'. Read-only is sufficient — "
+                "it does not allow changing protection."
+            ) from exc
         log.info("%s/%s has no classic branch protection on %s", owner, repo, branch)
 
     try:
@@ -144,7 +181,12 @@ def required_contexts(repo: str, owner: str, branch: str) -> frozenset[str]:
                 for entry in params.get("required_status_checks") or []:
                     if entry.get("context"):
                         contexts.add(entry["context"])
-    except GhError:
+    except GhError as exc:
+        if _is_permission_error(exc):
+            raise ProtectionUnreadable(
+                f"cannot read rulesets for {owner}/{repo}. "
+                "The token needs 'Administration: Read'."
+            ) from exc
         log.info("%s/%s exposes no rulesets", owner, repo)
 
     return frozenset(contexts)

--- a/dependabot-triage/tests/test_pipeline.py
+++ b/dependabot-triage/tests/test_pipeline.py
@@ -458,3 +458,44 @@ def test_ledger_shape_is_json_serialisable():
         ]
     }
     assert json.loads(json.dumps(payload))["decisions"][0]["action"] == "MERGE"
+
+
+# ---------------------------------------------------------------------------
+# Permission errors must never look like "nothing is configured"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "gh api failed (1): Resource not accessible by personal access token",
+        "gh api failed (1): Must have admin rights to Repository.",
+        "gh api failed (1): HTTP 403: Forbidden",
+        "gh api failed (1): Resource not accessible by integration",
+    ],
+)
+def test_permission_errors_are_recognised(message):
+    import gh
+
+    assert gh._is_permission_error(gh.GhError(message))
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "gh api failed (1): Branch not protected",
+        "gh api failed (1): HTTP 404: Not Found",
+    ],
+)
+def test_genuine_absence_is_not_a_permission_error(message):
+    """A repo with no protection is a real, valid state — not an error."""
+    import gh
+
+    assert not gh._is_permission_error(gh.GhError(message))
+
+
+def test_unreadable_protection_is_a_distinct_exception_type():
+    """So the orchestrator can abort on it specifically, rather than guessing."""
+    import gh
+
+    assert issubclass(gh.ProtectionUnreadable, gh.GhError)


### PR DESCRIPTION
## Summary

The first live dry run ([run 31900365307](https://github.com/wcmchenry3-stack/.github/actions/runs/31900365307)) exposed a design error in the token model.

Reading branch protection requires **`Administration: Read`**, which I deliberately left out of the token spec on the theory that withholding Administration was a safety win. It isn't — that permission is what lets the agent *see* what a branch requires. Without it the API refuses, and `required_contexts()` swallowed the refusal:

```
gh: wcmchenry3-stack/powerplayshistory_site has no classic branch protection on dev
harvest: powerplayshistory_site: 0 Dependabot PR(s), 0 required check(s)
```

That repo has **five** required checks. The agent saw zero.

This is the worst available failure mode. Guard G06 would have refused every PR on the repo, the log would have blamed repo configuration, and the actual cause — a missing token permission — would not have appeared anywhere. **An empty result must only ever mean "nothing is required here", never "I was not allowed to look."**

## Changes

- **`ProtectionUnreadable`** — a distinct exception raised when the API refuses for permission reasons, and *not* when a branch genuinely has no protection. Those two cases are now impossible to confuse.
- **The orchestrator aborts on it** and still sends the report, with the required fix named in the email, instead of continuing against a false empty set.
- **The ledger is written on the no-PRs path too**, so a missing artifact always means the job died rather than that there was nothing to do. That gap also showed up in the dry run.
- **README** records why the permission is `Administration: Read` and not write: the agent must be able to see protection to enforce G06 and G07, and must never be able to change it. The safety property is preserved — read-only cannot weaken a rule.

## Test plan

- [x] 186 tests pass; `guards.py` still at 100%
- [x] New tests cover permission-error detection and, importantly, that a genuine 404 "Branch not protected" is *not* treated as a permission error
- [ ] Add `Administration: Read` to `DEPENDABOT_TRIAGE_TOKEN`, then re-run the dry run and confirm `powerplayshistory_site` reports 5 required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn