### PR TITLE
fix(dependabot-triage): a dry run must still send the report

### DIFF
--- a/dependabot-triage/__main__.py
+++ b/dependabot-triage/__main__.py
@@ -82,6 +82,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--run-id", default=os.environ.get("GITHUB_RUN_ID", "local"))
     parser.add_argument("--ledger", type=Path, default=HERE / "out" / "ledger.json")
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--no-email",
+        action="store_true",
+        help="skip the report email (local testing); dry runs still email by default",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(
@@ -129,9 +134,9 @@ def main(argv: list[str] | None = None) -> int:
         )
         report_mod.send(
             body,
-            report_mod.subject_line(stats, config, now, aborted=str(exc)),
+            report_mod.subject_line(stats, config, now, aborted=str(exc), dry_run=args.dry_run),
             config,
-            dry_run=args.dry_run,
+            suppress=args.no_email,
         )
         return 1
 
@@ -175,7 +180,10 @@ def main(argv: list[str] | None = None) -> int:
             dry_run=args.dry_run,
         )
         report_mod.send(
-            body, report_mod.subject_line(stats, config, now), config, dry_run=args.dry_run
+            body,
+            report_mod.subject_line(stats, config, now, dry_run=args.dry_run),
+            config,
+            suppress=args.no_email,
         )
         return 0
 
@@ -298,9 +306,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     report_mod.send(
         body,
-        report_mod.subject_line(stats, config, now, aborted=aborted),
+        report_mod.subject_line(stats, config, now, aborted=aborted, dry_run=args.dry_run),
         config,
-        dry_run=args.dry_run,
+        suppress=args.no_email,
     )
 
     log.info(

--- a/dependabot-triage/report.py
+++ b/dependabot-triage/report.py
@@ -173,11 +173,19 @@ color:#1f2328;max-width:760px;margin:0 auto;padding:20px">
 </body></html>"""
 
 
-def send(html_body: str, subject: str, config: dict, *, dry_run: bool = True) -> bool:
-    """Deliver via Resend. Returns True when the email was accepted."""
+def send(html_body: str, subject: str, config: dict, *, suppress: bool = False) -> bool:
+    """Deliver via Resend. Returns True when the email was accepted.
+
+    Deliberately *not* gated on dry-run. A dry run suppresses GitHub mutations —
+    comments, rebases, merges — because those change the world. The report
+    changes nothing, and it is the thing a dry run exists to let you evaluate;
+    withholding it would make the staged rollout period produce no signal at all.
+    Dry-run reports are marked in both the subject and the body, so the two can
+    never be confused.
+    """
     api_key = os.environ.get("RESEND_API_KEY", "")
-    if dry_run or not api_key:
-        reason = "dry run" if dry_run else "RESEND_API_KEY not set"
+    if suppress or not api_key:
+        reason = "--no-email" if suppress else "RESEND_API_KEY not set"
         log.info("not sending email (%s); subject was %r", reason, subject)
         return False
 
@@ -210,11 +218,18 @@ def send(html_body: str, subject: str, config: dict, *, dry_run: bool = True) ->
     return False
 
 
-def subject_line(stats: dict, config: dict, when: datetime, aborted: str = "") -> str:
+def subject_line(
+    stats: dict, config: dict, when: datetime, aborted: str = "", dry_run: bool = False
+) -> str:
     prefix = config["report"]["subject_prefix"]
+    if dry_run:
+        prefix = f"[DRY RUN] {prefix}"
     if aborted:
         return f"{prefix} — ABORTED — {when:%a %d %b}"
     return (
-        f"{prefix} — {stats['merged']} merged, "
+        f"{prefix} — {stats['merged']} would merge, "
+        f"{stats['seen'] - stats['merged']} pending — {when:%a %d %b}"
+        if dry_run
+        else f"{prefix} — {stats['merged']} merged, "
         f"{stats['seen'] - stats['merged']} pending — {when:%a %d %b}"
     )

--- a/dependabot-triage/tests/test_pipeline.py
+++ b/dependabot-triage/tests/test_pipeline.py
@@ -445,9 +445,41 @@ def test_summary_reports_the_abort_reason_without_calling_a_model():
     assert "Nothing further was merged" in text
 
 
-def test_send_is_a_noop_during_a_dry_run():
+def test_send_is_suppressed_only_by_the_explicit_flag():
     config = {"report": {"from_address": "a@b.c", "to_address": "d@e.f"}}
-    assert report_mod.send("<p>x</p>", "subject", config, dry_run=True) is False
+    assert report_mod.send("<p>x</p>", "subject", config, suppress=True) is False
+
+
+def test_a_dry_run_still_emails(monkeypatch):
+    """A dry run suppresses GitHub mutations, never the report.
+
+    The report changes nothing and is the whole point of running dry; the
+    two-week rollout period would produce no signal at all if it were withheld.
+    """
+    sent = {}
+    monkeypatch.setenv("RESEND_API_KEY", "re_test")
+    monkeypatch.setattr(
+        report_mod.urllib.request,
+        "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("network")),
+    )
+    config = {"report": {"from_address": "a@b.c", "to_address": "d@e.f"}}
+    # suppress defaults to False, so it attempts delivery rather than skipping.
+    try:
+        report_mod.send("<p>x</p>", "subject", config)
+    except AssertionError as exc:
+        sent["attempted"] = str(exc) == "network"
+    assert sent.get("attempted"), "send() should attempt delivery when not explicitly suppressed"
+
+
+def test_dry_run_subject_is_unmistakable():
+    config = {"report": {"subject_prefix": "Dependabot Triage"}}
+    stats = {"merged": 3, "seen": 5}
+    live = report_mod.subject_line(stats, config, NOW)
+    dry = report_mod.subject_line(stats, config, NOW, dry_run=True)
+    assert dry.startswith("[DRY RUN]")
+    assert "would merge" in dry
+    assert "[DRY RUN]" not in live and "3 merged" in live
 
 
 def test_ledger_shape_is_json_serialisable():


### PR DESCRIPTION
## Summary

`--dry-run` was suppressing the report email along with the GitHub mutations. That is backwards.

A dry run should suppress **comments, rebases, and merges** — those change the world. The **report changes nothing**, and it is the entire thing a dry run exists to let you evaluate.

As written, the planned two-week dry-run rollout would have produced **zero emails**. No classifications to sanity-check, no autonomy-rate signal, no test of Resend — which is most of the reason for running dry at all.

## Changes

- `send()` is gated on an explicit `--no-email` flag instead of `dry_run`
- Dry-run reports are marked in the **subject** (`[DRY RUN] Dependabot Triage — 3 would merge, …`) as well as the existing body banner, so a dry report can never be mistaken for a live one
- `--no-email` is kept for local runs where mail is unwanted

## How it was found

The second dry run ([31900932598](https://github.com/wcmchenry3-stack/.github/actions/runs/31900932598)) reported success, classified nothing, and mailed nothing:

```
report: not sending email (dry run); subject was 'Dependabot Triage — 0 merged, 0 pending'
```

That run *did* confirm the previous fix worked — `powerplayshistory_site` went from `0 required check(s)` to `5`.

## Test plan

- [x] 188 tests pass, `guards.py` still 100%
- [x] New tests assert a dry run attempts delivery, and that dry/live subjects are distinguishable
- [ ] Re-run dry against all six repos and confirm an email actually arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn