### PR TITLE
fix(dependabot-triage): stream model calls so a large output budget is allowed

### DIFF
--- a/dependabot-triage/assess.py
+++ b/dependabot-triage/assess.py
@@ -118,11 +118,11 @@ def assess(harvests: list[RepoHarvest], client: Client, config: dict) -> dict[st
     # input is anywhere near the context limit. Chunk on PR count as well.
     if should_chunk(token_count, ceiling) or pr_count > max_prs:
         log.info(
-            "assessing per repo (%d PRs, %d tokens; limits %d PRs, %d tokens)",
+            "assessing per repo: %d PRs / %d tokens exceeds limit of %d PRs / %d tokens",
             pr_count,
+            token_count,
             max_prs,
             ceiling,
-            token_count,
         )
         raw_items: list[dict] = []
         for harvest in harvests:

--- a/dependabot-triage/llm.py
+++ b/dependabot-triage/llm.py
@@ -81,7 +81,13 @@ class Client:
             kwargs["output_config"]["format"] = {"type": "json_schema", "schema": schema}
 
         log.info("%s: calling %s (effort=%s)", phase, model, effort)
-        response = self._client.messages.create(**kwargs)
+        # Always stream. The SDK refuses a non-streaming request whose max_tokens
+        # implies it could run past ~10 minutes, because idle connections get
+        # dropped; the assessment's output budget is well over that line.
+        # get_final_message() gives the same object create() would have returned,
+        # so nothing downstream changes.
+        with self._client.messages.stream(**kwargs) as stream:
+            response = stream.get_final_message()
 
         usage = response.usage.model_dump() if hasattr(response.usage, "model_dump") else {}
         self.budget.record(phase, model, usage)


### PR DESCRIPTION
## Summary

The previous fix raised the assessment output budget to 32k. That tripped the SDK's own guard, on run [31903634304](https://github.com/wcmchenry3-stack/.github/actions/runs/31903634304):

```
ValueError: Streaming is required for operations that may take longer than 10 minutes.
```

The SDK refuses a non-streaming request whose `max_tokens` implies it could run past ~10 minutes, because idle HTTP connections get dropped. I raised the budget without switching transport — trading a truncated response for a hard failure *before the first call*, which is arguably worse.

All model calls now stream and read the result with `get_final_message()`, which returns the same object `create()` did. Nothing downstream changes.

Streaming is the correct default here anyway: the assessment is the longest call in the run, and the earlier non-streaming call already took **3.5 minutes**, which is close to the range where connections start getting dropped.

## Also

Fixes the argument order in the chunking log line, which printed:

```
assessing per repo (18 PRs, 8 tokens; limits 150000 PRs, 30895 tokens)
```

Values paired with the wrong labels. Now:

```
assessing per repo: 18 PRs / 30895 tokens exceeds limit of 8 PRs / 150000 tokens
```

## What did work

Harvest is solid and unchanged across three consecutive runs — all six repos, correct required-check counts (5/5/7/6/5/5), 18 PRs found. Chunking correctly decided to split per repo. The failure was the very first model call.

## Test plan

- [x] 191 tests pass, `guards.py` still 100%
- [x] Verified against the real SDK surface with a stubbed transport: the streaming path is used, `create()` is never called, and `max_tokens=32000` is passed through
- [ ] Re-run dry across all six and confirm the assessment completes and an email arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn