### PR TITLE
fix(dependabot-triage): do not send effort to models that reject it

### DIFF
--- a/dependabot-triage/config.yml
+++ b/dependabot-triage/config.yml
@@ -67,12 +67,17 @@ models:
   summary: claude-haiku-4-5
   escalate: claude-opus-5 # workflow_dispatch only, never the nightly path
 
+# `output_config.effort` is not accepted by every model — Haiku 4.5 rejects it
+# with a 400. Roles running on Haiku therefore leave it empty, which the client
+# translates into omitting the parameter entirely. If you move a role onto an
+# effort-capable model, set a level here; tests/test_config_contract.py enforces
+# that the two stay consistent.
 effort:
-  assess: medium
-  adversary: low
-  diagnose: low
-  delta: low
-  summary: low
+  assess: medium # claude-sonnet-5 — supported
+  adversary: "" # claude-haiku-4-5 — not supported
+  diagnose: "" # claude-haiku-4-5 — not supported
+  delta: "" # claude-haiku-4-5 — not supported
+  summary: "" # claude-haiku-4-5 — not supported
 
 # Per-PR kill switch.
 hold_label: "dependabot-triage:hold"

--- a/dependabot-triage/llm.py
+++ b/dependabot-triage/llm.py
@@ -24,6 +24,29 @@ log = logging.getLogger(__name__)
 # run instead of spinning against the wall clock.
 MAX_RETRIES = 3
 
+# `output_config.effort` is not universal: Haiku 4.5 and Sonnet 4.5 reject it
+# with a 400. This is an allowlist rather than a denylist so an unrecognised
+# model silently omits the parameter instead of failing the run — the cost of
+# omitting it is slightly different pacing, the cost of sending it is a crash.
+EFFORT_CAPABLE_MODELS = frozenset(
+    {
+        "claude-opus-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-sonnet-5",
+        "claude-sonnet-4-6",
+        "claude-fable-5",
+        "claude-mythos-5",
+    }
+)
+
+
+def supports_effort(model: str) -> bool:
+    """Whether ``model`` accepts ``output_config.effort``."""
+    return model in EFFORT_CAPABLE_MODELS
+
 
 class ModelResponseInvalid(RuntimeError):
     """The model returned something the schema does not allow."""
@@ -70,15 +93,22 @@ class Client:
         if cache_system:
             system_blocks[0]["cache_control"] = {"type": "ephemeral"}
 
+        output_config: dict[str, Any] = {}
+        if supports_effort(model):
+            output_config["effort"] = effort
+        elif effort:
+            log.debug("%s: %s does not accept effort; omitting it", phase, model)
+        if schema is not None:
+            output_config["format"] = {"type": "json_schema", "schema": schema}
+
         kwargs: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens,
             "system": system_blocks,
             "messages": [{"role": "user", "content": prompt}],
-            "output_config": {"effort": effort},
         }
-        if schema is not None:
-            kwargs["output_config"]["format"] = {"type": "json_schema", "schema": schema}
+        if output_config:
+            kwargs["output_config"] = output_config
 
         log.info("%s: calling %s (effort=%s)", phase, model, effort)
         # Always stream. The SDK refuses a non-streaming request whose max_tokens

--- a/dependabot-triage/tests/test_config_contract.py
+++ b/dependabot-triage/tests/test_config_contract.py
@@ -1,0 +1,84 @@
+"""Contract tests between config.yml and what the API will actually accept.
+
+Every failure this suite guards against has already happened in production once.
+They share a shape: the code was internally consistent and the unit tests passed,
+but the request the API received was rejected. These tests assert the *request*
+is valid, not just that the code runs.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import budget as budget_mod  # noqa: E402
+import llm  # noqa: E402
+
+CONFIG = yaml.safe_load((Path(__file__).parent.parent / "config.yml").read_text(encoding="utf-8"))
+
+
+def _configured_models() -> dict[str, str]:
+    return dict(CONFIG["models"])
+
+
+def test_every_configured_model_has_a_published_price():
+    """An unpriced model silently disables the spend ceiling."""
+    for role, model in _configured_models().items():
+        assert model in budget_mod.PRICING, f"{role}={model} has no entry in PRICING"
+
+
+def test_effort_is_only_configured_for_models_that_accept_it():
+    """Haiku 4.5 rejects `output_config.effort` with a 400.
+
+    This exact combination — effort: low on claude-haiku-4-5 — crashed a live
+    run at the adversarial-review step after five successful assessment calls.
+    """
+    for role, effort in CONFIG["effort"].items():
+        model = CONFIG["models"].get(role)
+        if model is None or not effort:
+            continue
+        if not llm.supports_effort(model):
+            pytest.fail(
+                f"config sets effort={effort!r} for role {role!r}, but {model} "
+                "rejects the effort parameter. Remove the effort entry or use a "
+                "model from llm.EFFORT_CAPABLE_MODELS."
+            )
+
+
+def test_every_effort_role_maps_to_a_real_model_role():
+    """A typo in an effort key would otherwise be silently ignored."""
+    unknown = set(CONFIG["effort"]) - set(CONFIG["models"])
+    assert not unknown, f"effort roles with no matching model: {sorted(unknown)}"
+
+
+@pytest.mark.parametrize("model", ["claude-haiku-4-5", "claude-sonnet-4-5"])
+def test_known_models_without_effort_support_are_excluded(model):
+    assert not llm.supports_effort(model)
+
+
+@pytest.mark.parametrize("model", ["claude-opus-5", "claude-sonnet-5", "claude-opus-4-8"])
+def test_known_models_with_effort_support_are_included(model):
+    assert llm.supports_effort(model)
+
+
+def test_unknown_model_omits_effort_rather_than_risking_a_400():
+    """Allowlist, not denylist: omitting effort costs pacing, sending it crashes."""
+    assert not llm.supports_effort("claude-some-future-model")
+
+
+def test_caps_and_budgets_are_positive():
+    assert CONFIG["caps"]["max_merges_per_repo"] > 0
+    assert CONFIG["caps"]["max_merges_total"] >= CONFIG["caps"]["max_merges_per_repo"]
+    assert CONFIG["budget"]["max_per_run"] > 0
+    assert CONFIG["budget"]["max_per_month"] >= CONFIG["budget"]["max_per_run"]
+
+
+def test_assessment_output_budget_leaves_room_for_a_full_chunk():
+    """Too small and the response truncates; that aborted a live run."""
+    assert CONFIG["budget"]["assessment_max_output_tokens"] >= 16000
+    assert CONFIG["budget"]["max_prs_per_assessment"] <= 12


### PR DESCRIPTION
## Summary

Run [31903886666](https://github.com/wcmchenry3-stack/.github/actions/runs/31903886666) got **much** further — all five chunked assessment calls succeeded — then died at the adversarial-review step:

```
anthropic.BadRequestError: 400 - This model does not support the effort parameter.
```

Haiku 4.5 rejects `output_config.effort`. `config.yml` set `effort: low` for all four Haiku roles.

The client now consults an allowlist of effort-capable models and omits the parameter otherwise. **Allowlist, not denylist** — an unknown model omitting effort costs slightly different pacing; an unknown model being *sent* effort costs the entire run.

## The more important change

`tests/test_config_contract.py` asserts that the request `config.yml` produces is one the API will actually accept:

- every configured model has a published price *(an unpriced model silently disables the spend ceiling)*
- `effort` is only set for models that accept it
- effort roles map to real model roles *(a typo would otherwise be silently ignored)*
- the output budget is large enough not to truncate *(that aborted an earlier run)*

It **fails on the old config and passes on the new one** — verified before writing the fix.

This is the gap behind the last four failures. Each had internally consistent code and passing unit tests, but produced a *request* the API rejected. Unit tests assert the code; these assert the request.

## Progress this run

| Phase | Result |
|---|---|
| Harvest, 6 repos | ✅ 18 PRs, all check counts correct |
| Chunking decision | ✅ split per repo on PR count |
| Streaming | ✅ no timeout guard |
| **5 assessment calls** | ✅ all succeeded |
| Adversarial review | ❌ 400 on effort |

## Test plan

- [x] 202 tests pass, `guards.py` still 100%
- [x] Contract test demonstrated failing on the old config
- [ ] Re-run dry across all six; expect it to reach the report and email

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn