### PR TITLE
fix(dependabot-triage): separate change risk from CI state, and date the prompts

### DIFF
--- a/dependabot-triage/assess.py
+++ b/dependabot-triage/assess.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime
 from pathlib import Path
 
 from budget import should_chunk
@@ -67,9 +68,15 @@ def _describe_pr(pr: PullRequest, required: frozenset[str], base: str) -> str:
     return "\n".join(lines)
 
 
-def build_corpus(harvests: list[RepoHarvest]) -> str:
-    """Assemble the evidence for every open Dependabot PR across the stack."""
-    blocks: list[str] = []
+def build_corpus(harvests: list[RepoHarvest], today: str | None = None) -> str:
+    """Assemble the evidence for every open Dependabot PR across the stack.
+
+    The date is stated explicitly because Q13 asks how fresh a release is, and a
+    model with no reference point will guess. An adversarial reviewer once
+    blocked a good merge by calling week-old changelog dates "future-dated".
+    """
+    today = today or datetime.now(UTC).strftime("%Y-%m-%d")
+    blocks: list[str] = [f"Today's date is {today}."]
     for harvest in harvests:
         prs = harvest.dependabot_prs
         if not prs:
@@ -99,9 +106,10 @@ def assess(harvests: list[RepoHarvest], client: Client, config: dict) -> dict[st
     Any PR the model fails to return an assessment for is defaulted to MEDIUM —
     a silent omission must never read as permission to merge.
     """
-    corpus = build_corpus(harvests)
-    if not corpus:
+    pr_total = sum(len(h.dependabot_prs) for h in harvests)
+    if pr_total == 0:
         return {}
+    corpus = build_corpus(harvests)
 
     model = config["models"]["assess"]
     effort = config["effort"]["assess"]
@@ -109,7 +117,7 @@ def assess(harvests: list[RepoHarvest], client: Client, config: dict) -> dict[st
     max_prs = config["budget"].get("max_prs_per_assessment", 8)
     max_out = config["budget"].get("assessment_max_output_tokens", 32000)
 
-    pr_count = sum(len(h.dependabot_prs) for h in harvests)
+    pr_count = pr_total
     token_count = client.count_tokens(model, ASSESS_PROMPT, corpus)
     log.info("assessment corpus is %d tokens across %d PR(s)", token_count, pr_count)
 

--- a/dependabot-triage/execute.py
+++ b/dependabot-triage/execute.py
@@ -354,6 +354,18 @@ def execute(
             )
         )
 
+    # Mark PRs whose required checks were already failing when the run began.
+    # They were not mergeable tonight by anyone, so they are excluded from the
+    # autonomy-rate denominator — otherwise the metric drifts into measuring repo
+    # health rather than how much work the agent is actually taking on.
+    already_red = {
+        pr.slug: bool(pr.failing_required(h.baseline.required_contexts))
+        for h in harvests
+        for pr in h.dependabot_prs
+    }
+    for decision in result.decisions:
+        decision.pre_existing_red = already_red.get(decision.slug, False)
+
     for decision in result.decisions:
         if decision.action in (Action.COMMENT, Action.SKIP) or decision.merged:
             gh.comment(

--- a/dependabot-triage/metrics.py
+++ b/dependabot-triage/metrics.py
@@ -69,6 +69,7 @@ def record_run(
                     "merged": decision.merged,
                     "rebased": decision.rebased,
                     "deferred": decision.deferred,
+                    "pre_existing_red": decision.pre_existing_red,
                     "deciding_question": decision.deciding_question,
                     "failed_guard": decision.failed_guard,
                     "reason": decision.reason,
@@ -106,10 +107,10 @@ def summarise(decisions: list[Decision]) -> dict:
     deferred = [d for d in decisions if d.deferred]
     blocked = [d for d in decisions if d.action is Action.SKIP]
 
-    # A PR that was already red before the run started, through no fault of the
-    # bump, was never mergeable tonight — counting it against the agent would
+    # A PR that was already red before the run started, or that the run never got
+    # to, was never mergeable tonight — counting either against the agent would
     # make the autonomy rate measure repo health rather than agent behaviour.
-    eligible = [d for d in decisions if not d.deferred]
+    eligible = [d for d in decisions if not d.deferred and not d.pre_existing_red]
 
     return {
         "seen": len(decisions),
@@ -117,6 +118,7 @@ def summarise(decisions: list[Decision]) -> dict:
         "rebased_then_merged": len([d for d in merged if d.rebased]),
         "deferred": len(deferred),
         "blocked_by_guard": len(blocked),
+        "pre_existing_red": len([d for d in decisions if d.pre_existing_red]),
         "eligible": len(eligible),
         "autonomy_rate": round(len(merged) / len(eligible), 4) if eligible else None,
         "by_tier": dict(Counter(d.tier.value for d in decisions)),
@@ -170,7 +172,7 @@ def rolling(days: int = 30, now: datetime | None = None) -> dict:
         return {"window_days": days, "decisions": 0, "autonomy_rate": None, "merged": 0}
 
     merged = [d for d in decisions if d.get("merged")]
-    eligible = [d for d in decisions if not d.get("deferred")]
+    eligible = [d for d in decisions if not d.get("deferred") and not d.get("pre_existing_red")]
     return {
         "window_days": days,
         "decisions": len(decisions),

--- a/dependabot-triage/models.py
+++ b/dependabot-triage/models.py
@@ -182,6 +182,10 @@ class Decision:
     deferred: bool = False
     deciding_question: str = ""
     diagnosis: str = ""
+    # True when a required check was already failing when the run started. Such a
+    # PR was never mergeable tonight by anyone, so counting it against the agent
+    # would make the autonomy rate measure repo health rather than agent behaviour.
+    pre_existing_red: bool = False
 
     @property
     def slug(self) -> str:

--- a/dependabot-triage/prompts/adversary.md
+++ b/dependabot-triage/prompts/adversary.md
@@ -11,6 +11,8 @@ You are not being asked to be agreeable or to confirm the other reviewer's work.
 - a changelog entry that mentions a behavioural change without calling it breaking
 - a version published so recently that nobody has exercised it yet
 
+Today's date is supplied in the input. Use it for any recency claim — do not guess whether a release date is in the past or the future, and do not treat a date you have not compared against today as evidence of anything.
+
 State your objection only if it is **concrete and checkable** — name the package, the constraint, and what would break. "It could theoretically break something" is not an objection; it applies to every change ever made and is therefore useless.
 
 If you genuinely cannot find a specific problem, say so plainly. A false alarm costs a merge that should have happened, and enough of those make this system worth ignoring.

--- a/dependabot-triage/prompts/assess.md
+++ b/dependabot-triage/prompts/assess.md
@@ -4,10 +4,18 @@ Classify every pull request you are given into exactly one tier.
 
 ## Tiers
 
-- **LOW** — merging this unattended tonight is safe. Reserved for changes whose failure mode is caught by the repo's existing required checks.
+- **LOW** — this change is safe to merge unattended. Reserved for changes whose failure mode would be caught by the repo's existing required checks.
 - **MEDIUM** — probably fine, but wants a human eye. Anything you are not confident about belongs here.
 - **HIGH** — a real chance of breaking something that CI would not catch.
-- **BLOCKED** — must not merge: the diff touches something outside the dependency manifests, or a precondition is plainly unmet.
+- **BLOCKED** — the diff touches files outside the dependency manifests, lockfiles, and workflow version pins. This tier is about **paths only**.
+
+### Tier the change, not the current CI state
+
+Whether checks are red right now is **not your decision to make**. A deterministic layer re-checks every required status immediately before merging and refuses anything that is not green, with a precise reason. It does this better than you can, and it does it again after any rebase.
+
+So: if a patch bump to a dev dependency happens to sit on a branch with a failing unrelated check, it is still **LOW**. Say in the rationale that CI is currently red and why you think so, but do not let it move the tier.
+
+Mixing the two corrupts both signals. The tier is a judgment about the change that only you can make; CI state is a fact the machinery already has. When they are conflated, the reports stop showing which dependency updates are actually risky, and start showing which branches happen to be broken today.
 
 Only LOW is eligible for automated merge. **When you are uncertain between two tiers, pick the higher one.** A PR left for the morning costs a few minutes. A bad merge at 1am costs a debugging session, and it costs trust in this whole system.
 
@@ -34,6 +42,6 @@ Answer these for each PR. Record your reasoning for Q1, Q3, Q5, and Q12 in every
 
 Emit one assessment per pull request supplied, matching the provided schema exactly.
 
-- `deciding_question` names the rubric question that drove the tier. Use `NONE` only when the tier is LOW.
+- `deciding_question` names the rubric question that drove the tier. It must match what your `rationale` actually argues — if the rationale is about a major version, the question is `Q1_semver`, not something else. A mislabelled question is worse than none: these are aggregated to work out where the ceiling is, so a wrong label sends that analysis somewhere useless. Use `NONE` only when the tier is LOW.
 - `rationale` is one sentence and will be posted verbatim as a PR comment and shown in an email. Write it for a reader who has not seen the diff. Say what the change is and why it landed in this tier.
 - `packages` lists the resolved `name@version` entries this PR moves. It is used to detect drift if Dependabot rebases the branch, so be precise.

--- a/dependabot-triage/tests/test_pipeline.py
+++ b/dependabot-triage/tests/test_pipeline.py
@@ -11,7 +11,7 @@ import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from conftest import make_pr
+from conftest import make_baseline, make_pr
 
 import budget as budget_mod
 import execute as execute_mod
@@ -531,3 +531,53 @@ def test_unreadable_protection_is_a_distinct_exception_type():
     import gh
 
     assert issubclass(gh.ProtectionUnreadable, gh.GhError)
+
+
+# ---------------------------------------------------------------------------
+# The autonomy rate must measure the agent, not repo health
+# ---------------------------------------------------------------------------
+
+
+def test_already_red_prs_are_excluded_from_the_denominator():
+    """A PR whose CI was red before the run was never mergeable by anyone.
+
+    The first full run merged 3 of 18, which read as a 17% autonomy rate. Six of
+    those PRs had failing required checks before the run started and eight were
+    majors that are never auto-merged by policy — the genuinely eligible pool was
+    four. Counting the unmergeable ones makes the metric track repo health.
+    """
+    decisions = [
+        _decision(number=1),
+        _decision(number=2, merged=False, action=Action.COMMENT, pre_existing_red=True),
+        _decision(number=3, merged=False, action=Action.COMMENT, pre_existing_red=True),
+    ]
+    stats = metrics_mod.summarise(decisions)
+    assert stats["pre_existing_red"] == 2
+    assert stats["eligible"] == 1
+    assert stats["autonomy_rate"] == 1.0
+
+
+def test_rolling_window_also_excludes_already_red(tmp_path, monkeypatch):
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    metrics_mod.record_run(
+        [
+            _decision(number=1),
+            _decision(number=2, merged=False, action=Action.COMMENT, pre_existing_red=True),
+        ],
+        {},
+        run_id="r",
+        now=NOW,
+        dry_run=False,
+    )
+    assert metrics_mod.rolling(now=NOW + timedelta(hours=1))["autonomy_rate"] == 1.0
+
+
+def test_corpus_states_todays_date_for_recency_questions():
+    """Q13 asks how fresh a release is; without a date the model guesses."""
+    import assess as assess_mod
+    from harvest import RepoHarvest
+
+    h = RepoHarvest(
+        repo="r", base="dev", merge_method="squash", baseline=make_baseline(), prs=[make_pr()]
+    )
+    assert "Today's date is 2026-03-04." in assess_mod.build_corpus([h], today="2026-03-04")


### PR DESCRIPTION
## Summary

Four issues from the first successful full run ([31904411756](https://github.com/wcmchenry3-stack/.github/actions/runs/31904411756) — 18 PRs, 3 merged, $0.48, email delivered).

### 1. Tier conflated the change's risk with current CI state

Both `BLOCKED` verdicts actually meant "checks are red right now", not "the diff touches something it shouldn't". `RulersAI#663` was labelled `Q7_stray_paths` while touching only an allowlisted workflow file — the rationale didn't mention paths at all.

The prompt now says plainly that **CI state is not the model's call**: a deterministic layer re-checks every required status immediately before merge, and again after any rebase. It does that better, and it does it at the right moment. `BLOCKED` is now explicitly about **paths only**.

This was costing both signals — the reports were showing which *branches were broken*, not which *updates were risky*.

### 2. `deciding_question` could disagree with its own rationale

These are aggregated to work out where the ceiling is, so a wrong label sends that analysis somewhere useless. The prompt now requires the two to match.

### 3. Neither prompt knew what day it was

The adversarial reviewer blocked a sound `react-navigation` merge, claiming changelog dates `2026-08-07` and `2026-08-05` were **"future-dated"**. Both were over a week in the past. It had no reference point, so it guessed.

Q13 ("was this published in the last 72 hours?") had exactly the same blind spot and nobody noticed, because it never fired. Both prompts now receive today's date.

### 4. The autonomy rate was measuring the wrong thing

3-of-18 reads as a 17% autonomy rate. But six PRs had failing required checks before the run began — unmergeable by anyone — and eight were majors that never auto-merge by policy. The genuinely eligible pool was **four**, of which it merged three, with the fourth lost to the date bug above.

Decisions now carry `pre_existing_red`, excluded from the denominator, so the metric tracks the agent rather than repo health.

## A regression this caught

Adding the date header made `build_corpus()` unconditionally truthy, breaking the "no PRs means no model call" short-circuit — which would have spent money doing nothing on a quiet night. An existing test caught it. The gate now checks PR count, which is what it should always have checked.

## On loosening the controls

Deliberately **not** loosening. The eight majors include `cryptography >=49→>=50` and a fragmented Expo SDK 56→57 family split across four PRs — precisely the changes that should not merge unattended. The six red-CI ones are a repo-health problem no policy change addresses. The low number was a measurement bug, which is what this PR fixes.

## Test plan

- [x] 205 tests pass, `guards.py` still 100%
- [ ] Re-run dry and confirm: no BLOCKED for merely-red CI, questions match rationales, react-navigation is no longer downgraded on a date error, and the reported autonomy rate reflects the eligible pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn