### PR TITLE
fix(dependabot-triage): ground adversarial review in the actual diff

### DIFF
--- a/dependabot-triage/assess.py
+++ b/dependabot-triage/assess.py
@@ -87,6 +87,31 @@ def build_corpus(harvests: list[RepoHarvest], today: str | None = None) -> str:
     return "\n\n".join(blocks)
 
 
+# Lockfiles are huge and machine-generated. Version *constraints* live in the
+# manifests, which is what an objection about a version spec has to cite.
+MANIFEST_HINTS = (
+    "package.json",
+    "requirements",
+    "pyproject.toml",
+    "Pipfile",
+    "go.mod",
+    ".github/workflows/",
+)
+MANIFEST_DIFF_CHARS = 2500
+
+
+def manifest_diff(pr: PullRequest) -> str:
+    """The changed lines from manifests only, for grounding a review in evidence."""
+    chunks: list[str] = []
+    for f in pr.files:
+        if "lock" in f.path.lower() or not any(h in f.path for h in MANIFEST_HINTS):
+            continue
+        lines = [ln for ln in f.changed_lines() if ln.strip() not in ("+", "-")]
+        if lines:
+            chunks.append("\n".join([f"--- {f.path}", *lines]))
+    return "\n\n".join(chunks)[:MANIFEST_DIFF_CHARS]
+
+
 def _to_assessment(raw: dict) -> Assessment:
     return Assessment(
         repo=raw["repo"],
@@ -201,6 +226,10 @@ def adversarial_review(
             f"Changed files: {', '.join(pr.paths)}",
             f"Packages moved: {', '.join(assessment.packages) or 'unknown'}",
             f"Reviewer's rationale: {assessment.rationale}",
+            "",
+            "Manifest diff — these are the actual changed lines. Any objection about a",
+            "version constraint, range, or pin must quote from here:",
+            manifest_diff(pr) or "(no manifest changes; lockfile-only update)",
             "",
             "Release notes (truncated):",
             pr.body[:BODY_CHARS] or "(none supplied)",

--- a/dependabot-triage/prompts/adversary.md
+++ b/dependabot-triage/prompts/adversary.md
@@ -13,6 +13,14 @@ You are not being asked to be agreeable or to confirm the other reviewer's work.
 
 Today's date is supplied in the input. Use it for any recency claim — do not guess whether a release date is in the past or the future, and do not treat a date you have not compared against today as evidence of anything.
 
+## Ground every claim in the diff you were given
+
+You are shown the actual changed manifest lines. **Any claim about a version constraint, range, pin, or spec must quote a line from that diff.** If you want to say a package uses a dynamic or unusual version range, that range has to appear there.
+
+Do not infer version specs from group names, `update-types` metadata, release-note prose, or the PR title. Dependabot group configuration contains words like `minor`, `patch`, and `latest` that are **not** version constraints — reading them as constraints has already produced false objections that blocked good merges.
+
+If the diff does not contain the evidence for your objection, you do not have an objection. Say SAFE.
+
 State your objection only if it is **concrete and checkable** — name the package, the constraint, and what would break. "It could theoretically break something" is not an objection; it applies to every change ever made and is therefore useless.
 
 If you genuinely cannot find a specific problem, say so plainly. A false alarm costs a merge that should have happened, and enough of those make this system worth ignoring.

--- a/dependabot-triage/tests/test_execute.py
+++ b/dependabot-triage/tests/test_execute.py
@@ -427,3 +427,50 @@ def test_assessment_requests_the_configured_output_budget():
 
     assess_mod.assess([_harvest([make_pr()])], Recorder(), CONFIG)
     assert seen["assess"] == 32000
+
+
+def test_adversary_receives_the_manifest_diff_not_just_names():
+    """Two live false positives came from the adversary having no diff to cite.
+
+    It invented a `latest-minor` constraint for sharp — the real diff was
+    `^0.35.2` to `^0.35.3` — and blocked a good merge. It can only be asked for
+    concrete evidence if it is given concrete evidence.
+    """
+    from models import ChangedFile
+
+    seen = {}
+
+    class Recorder(FakeClient):
+        def complete(self, **kw):
+            seen[kw["phase"]] = kw["prompt"]
+            return super().complete(**kw)
+
+    pr = make_pr(
+        files=[
+            ChangedFile(
+                path="package.json",
+                patch='@@\n-    "sharp": "^0.35.2",\n+    "sharp": "^0.35.3",\n',
+            ),
+            ChangedFile(path="package-lock.json", patch="@@\n+ noise\n"),
+        ]
+    )
+    _run([_harvest([pr])], {pr.slug: _low(pr)}, Recorder())
+    prompt = seen["adversary"]
+    assert '"sharp": "^0.35.3"' in prompt, "manifest diff missing from adversary prompt"
+    assert "noise" not in prompt, "lockfile should not be included"
+
+
+def test_lockfile_only_pr_tells_the_adversary_so_explicitly():
+    """Silence would invite the model to guess at constraints it cannot see."""
+    from models import ChangedFile
+
+    seen = {}
+
+    class Recorder(FakeClient):
+        def complete(self, **kw):
+            seen[kw["phase"]] = kw["prompt"]
+            return super().complete(**kw)
+
+    pr = make_pr(files=[ChangedFile(path="package-lock.json", patch="@@\n+ x\n")])
+    _run([_harvest([pr])], {pr.slug: _low(pr)}, Recorder())
+    assert "lockfile-only update" in seen["adversary"]


### PR DESCRIPTION
## Summary

The adversarial reviewer has produced **two false positives out of two objections**, and the second blocked a real merge in the first live run ([31906208568](https://github.com/wcmchenry3-stack/.github/actions/runs/31906208568)).

It claimed `wcm_portfolio_site#166` set `sharp` to `latest-minor` — "a dynamic version constraint that will pull whatever the latest minor release is at install time", breaking reproducible builds.

The actual diff:

```diff
-    "sharp": "^0.35.2",
+    "sharp": "^0.35.3",
-    "globals": "^17.7.0",
+    "globals": "^17.11.0",
```

No such constraint exists in the PR. The phrase almost certainly came from Dependabot's **group metadata** (`update-types: ["minor", "patch"]`) being read as a version spec.

## Why it happened

Structural, not bad luck. The prompt asked for a **concrete, checkable objection** while supplying only file *names*, package names, the other reviewer's rationale, and release notes — **no diff**. Asked to be specific with nothing specific available, the model supplies specifics.

The first false positive had the identical shape: a recency claim ("these dates are future-dated") with no date to check against. Fixed by supplying the date. Same root cause, same fix.

## Changes

- The adversary now receives the **changed manifest lines**. Lockfiles are excluded — enormous, machine-generated, and version constraints live in manifests.
- The prompt requires any claim about a constraint, range, or pin to **quote from that diff**.
- It is told explicitly that group names and `update-types` metadata are *not* version constraints, and that absent evidence means `SAFE`.

## On whether to keep the adversary at all

Two for two is a bad record, and it is currently costing merges rather than preventing bad ones. I think the concept is sound and the implementation was under-informed — it was being asked to audit something it could not see. Worth one more run to judge on evidence. If it produces a third false positive *with* the diff in hand, the honest conclusion is that it is not earning its place.

## Test plan

- [x] 207 tests pass, `guards.py` still 100%
- [x] New tests assert the manifest diff reaches the adversary and lockfiles do not
- [ ] Re-run live on `wcm_portfolio_site` and confirm #166 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn