### PR TITLE
fix(dependabot-triage): disable adversarial review — 3 objections, 3 fabrications

### DIFF
--- a/dependabot-triage/config.yml
+++ b/dependabot-triage/config.yml
@@ -79,6 +79,28 @@ effort:
   delta: "" # claude-haiku-4-5 — not supported
   summary: "" # claude-haiku-4-5 — not supported
 
+# Adversarial second opinion on every LOW rating — DISABLED.
+#
+# The idea was a cheap independent reviewer arguing against each proposed merge,
+# to counteract the assessor's bias toward finishing the task. In practice it
+# raised three objections across four runs and all three were fabrications:
+#
+#   1. called changelog dates 2026-08-07 / 2026-08-05 "future-dated" (both past)
+#   2. claimed sharp was pinned to "latest-minor" (real diff: ^0.35.2 -> ^0.35.3)
+#   3. called a 2026-08-01 changelog entry "in the future" (14 days past)
+#
+# Zero real issues found, three good merges blocked. Objections 1 and 3 are the
+# same date-comparison error, and 3 was made *after* the prompt was given both
+# today's date and the manifest diff — so the failure survived the two fixes
+# aimed directly at it.
+#
+# Asking a small model to manufacture a specific objection reliably produces a
+# specific objection, whether or not one exists. The deterministic guards remain
+# the real safety layer, and unlike this they are 100% covered and cannot invent
+# anything. Set to true to re-enable, ideally on a stronger model first.
+adversary:
+  enabled: false
+
 # Per-PR kill switch.
 hold_label: "dependabot-triage:hold"
 

--- a/dependabot-triage/execute.py
+++ b/dependabot-triage/execute.py
@@ -179,7 +179,9 @@ def execute(
                 )
                 continue
 
-            still_low, objection = adversarial_review(pr, assessment, client, config)
+            still_low, objection = (True, "")
+            if config.get("adversary", {}).get("enabled", False):
+                still_low, objection = adversarial_review(pr, assessment, client, config)
             if not still_low:
                 result.decisions.append(
                     Decision(

--- a/dependabot-triage/tests/test_execute.py
+++ b/dependabot-triage/tests/test_execute.py
@@ -28,6 +28,7 @@ CONFIG = {
         "global_wall_clock": 14400,
     },
     "hold_label": "dependabot-triage:hold",
+    "adversary": {"enabled": True},
     "models": {
         "assess": "claude-sonnet-5",
         "adversary": "claude-haiku-4-5",
@@ -474,3 +475,24 @@ def test_lockfile_only_pr_tells_the_adversary_so_explicitly():
     pr = make_pr(files=[ChangedFile(path="package-lock.json", patch="@@\n+ x\n")])
     _run([_harvest([pr])], {pr.slug: _low(pr)}, Recorder())
     assert "lockfile-only update" in seen["adversary"]
+
+
+def test_adversary_is_skipped_when_disabled():
+    """Disabled by default after 3 objections, 3 fabrications, 0 real catches."""
+    config = {**CONFIG, "adversary": {"enabled": False}}
+    pr = make_pr()
+    client = FakeClient(adversary="UNSAFE: something invented")
+    result = execute_mod.execute(
+        [_harvest([pr])], {pr.slug: _low(pr)}, client, config, dry_run=True
+    )
+    assert "adversary" not in client.calls
+    assert result.decisions[0].action is Action.MERGE
+
+
+def test_absent_adversary_config_defaults_to_off():
+    """A missing key must not silently re-enable a layer we switched off."""
+    config = {k: v for k, v in CONFIG.items() if k != "adversary"}
+    pr = make_pr()
+    client = FakeClient(adversary="UNSAFE: invented")
+    execute_mod.execute([_harvest([pr])], {pr.slug: _low(pr)}, client, config, dry_run=True)
+    assert "adversary" not in client.calls


### PR DESCRIPTION
## Summary

I said the next run would decide whether this layer earns its place. It produced a third false positive, so it comes out.

## The record

| # | Objection | Reality |
|---|---|---|
| 1 | `BC-Arcade#2310` — changelog dates 2026-08-07 / 2026-08-05 are "future-dated" | Both in the **past**. Blocked a good merge. |
| 2 | `wcm_portfolio#166` — `sharp` pinned to `latest-minor`, a dynamic constraint | Real diff: `^0.35.2` → `^0.35.3`. Blocked a good merge. |
| 3 | `wcm_portfolio#166` — changelog entry dated 2026-08-01 is "in the future" | **14 days past.** Blocked the same merge again. |

**3 objections. 3 fabrications. 0 real issues. 3 good merges lost.**

Both live runs have now merged nothing, and this layer is the sole cause of both.

## Why this is a design failure, not tuning

Objections 1 and 3 are the *same* date-comparison error — and #3 was made **after** the prompt was given both today's date (#267) and the manifest diff (#268). Two fixes aimed directly at this failure did not stop it recurring. That is the signal that the approach is wrong rather than the inputs.

The underlying idea is sound: an independent reviewer arguing against each merge, to counteract the assessor's bias toward finishing the task. But instructing a small model to *manufacture a specific objection* reliably produces one, whether or not it exists. I asked for skepticism and got fabrication.

## What changed

Gated behind `adversary.enabled`, defaulting to `false` — and defaulting to `false` again when the key is absent, so it cannot be silently reinstated. Not deleted: re-enabling on a stronger model is a one-line change, and the full record is written into `config.yml` so whoever considers that knows what happened.

## What still protects you

The deterministic guards: **11 preconditions, 100% covered, re-verified against live API state immediately before every merge and again after any rebase.** Unlike this layer, they cannot invent anything.

The rubric still refuses majors, groups containing majors, peer-coupled families, security-surface packages, and anything on a repo with inadequate required checks. `LOW` remains the only mergeable tier.

## Test plan

- [x] 209 tests pass, `guards.py` still 100%
- [x] Tests assert the adversary is skipped when disabled, and when the config key is missing entirely
- [ ] Re-run live on `wcm_portfolio_site`; #166 should finally merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn