### PR TITLE
chore(dependabot-triage): enable all six repos for nightly dry runs

### DIFF
--- a/dependabot-triage/config.yml
+++ b/dependabot-triage/config.yml
@@ -14,23 +14,23 @@ repos:
     base: dev
     merge_method: merge # ruleset on this repo forbids squash
   - name: buffingchi_site
-    enabled: false
+    enabled: true
     base: dev
     merge_method: merge
   - name: BC-Arcade
-    enabled: false
+    enabled: true
     base: dev
     merge_method: squash
   - name: BookshelfAI
-    enabled: false
+    enabled: true
     base: dev
     merge_method: merge
   - name: wcm_portfolio_site
-    enabled: false
+    enabled: true
     base: dev
     merge_method: merge
   - name: RulersAI
-    enabled: false
+    enabled: true
     base: dev
     merge_method: merge
 


### PR DESCRIPTION
## Summary

Flips `enabled: true` for all six repos. **Scheduled runs stay dry.**

The workflow only passes `--no-dry-run` for a `workflow_dispatch` with `dry_run=false`:

```yaml
${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) && '--no-dry-run' || '--dry-run' }}
```

A `schedule` event fails that condition, so the cron reports without acting. This change only widens *what it reports on* — from one repo with zero Dependabot PRs to the whole stack.

## Why dry for now

The intent is a week of nightly emails showing what it would have done against real batches, before it gets authority to act unattended. Four clean merges on one unusually major-heavy day is encouraging but thin.

You keep the manual path in the meantime:

```
gh workflow run scheduled-dependabot-triage.yml --repo wcmchenry3-stack/.github \
  -f dry_run=false -f repos=<subset>
```

## To go live later

One expression in the workflow:

```yaml
${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)) && '--no-dry-run' || '--dry-run' }}
```

## Note

`adversary.enabled` stays `false` — the regex that flips the repo flags is scoped so it cannot re-enable it, and a test asserts the default is off.

## Test plan

- [x] 209 tests pass
- [ ] Tonight's 06:00 UTC run emails a `[DRY RUN]` report covering all six repos
- [ ] Nothing merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn