### PR TITLE
feat(dependabot-triage): rebuild branches whose lockfile disagrees with its manifest

### DIFF
--- a/dependabot-triage/config.yml
+++ b/dependabot-triage/config.yml
@@ -101,6 +101,14 @@ effort:
 adversary:
   enabled: false
 
+# Ask Dependabot to rebuild a branch when a red PR looks like a lockfile
+# desync rather than a genuine incompatibility. Dependabot does the rebuild, so
+# the agent still never writes a file. Recreate force-pushes, so it is refused
+# outright on any branch carrying human commits.
+remediate:
+  enabled: true
+  max_recreates_per_run: 4
+
 # Per-PR kill switch.
 hold_label: "dependabot-triage:hold"
 

--- a/dependabot-triage/diagnose.py
+++ b/dependabot-triage/diagnose.py
@@ -27,16 +27,30 @@ def _failed_check_names(pr: PullRequest, required: frozenset[str]) -> list[str]:
     return [c.name for c in pr.failing_required(required)]
 
 
-def _fetch_log_tail(repo: str, owner: str, number: int) -> str:
-    """Last lines of the failing job's log.
+def fetch_log_tail(repo: str, owner: str, number: int, head_ref: str = "") -> str:
+    """Last lines of the failing job's log for *this* PR.
+
+    Previously this listed the repository's most recent workflow run, which is
+    frequently a different branch entirely — so a diagnosis could confidently
+    describe someone else's failure. The run list is now filtered to the PR's
+    own head branch.
 
     Best-effort: the log endpoint is noisy and occasionally unavailable, and a
     missing log is a normal outcome rather than a reason to fail the run.
     """
-    try:
-        raw = gh._run(
-            ["run", "list", "--repo", f"{owner}/{repo}", "--limit", "1", "--json", "databaseId"]
+    args = ["run", "list", "--repo", f"{owner}/{repo}", "--limit", "1", "--json", "databaseId"]
+    if head_ref:
+        args += ["--branch", head_ref]
+    else:
+        log.warning(
+            "no head ref for %s#%s; skipping log fetch rather than "
+            "risk reading an unrelated run",
+            repo,
+            number,
         )
+        return ""
+    try:
+        raw = gh._run(args)
     except gh.GhError as exc:
         log.info("could not list runs for %s#%s: %s", repo, number, exc)
         return ""
@@ -76,7 +90,7 @@ def diagnose(
     if not failing:
         return ""
 
-    log_tail = "" if dry_run else _fetch_log_tail(pr.repo, config["owner"], pr.number)
+    log_tail = "" if dry_run else fetch_log_tail(pr.repo, config["owner"], pr.number, pr.head_ref)
 
     prompt = "\n".join(
         [

--- a/dependabot-triage/execute.py
+++ b/dependabot-triage/execute.py
@@ -13,8 +13,10 @@ import logging
 import time
 from dataclasses import dataclass, field
 
+import diagnose as diagnose_mod
 import gh
 import guards
+import remediate
 from assess import adversarial_review
 from harvest import RepoHarvest
 from llm import Client
@@ -126,6 +128,7 @@ def execute(
 
     result = ExecutionResult()
     pending: list[Pending] = []
+    recreates = 0
     started = time.monotonic()
 
     def budget_left() -> float:
@@ -165,6 +168,41 @@ def execute(
             blocking = [g for g in failed if g.guard_id != "G10"]
 
             if blocking:
+                # A PR blocked only on red checks may be red because its lockfile
+                # disagrees with its manifest, not because the bump is bad. Ask
+                # Dependabot to rebuild rather than writing to the branch here.
+                only_checks_failed = {g.guard_id for g in blocking} == {"G06"}
+                if (
+                    only_checks_failed
+                    and config.get("remediate", {}).get("enabled", False)
+                    and recreates < config.get("remediate", {}).get("max_recreates_per_run", 4)
+                ):
+                    log_text = (
+                        ""
+                        if dry_run
+                        else diagnose_mod.fetch_log_tail(pr.repo, owner, pr.number, pr.head_ref)
+                    )
+                    authors = [] if dry_run else gh.pr_commit_authors(pr.repo, owner, pr.number)
+                    ok, why = remediate.should_recreate(
+                        pr, harvest.baseline.required_contexts, log_text, authors
+                    )
+                    if ok:
+                        log.info("%s: asking Dependabot to recreate (%s)", pr.slug, why)
+                        gh.request_rebase(pr.repo, owner, pr.number, recreate=True, dry_run=dry_run)
+                        recreates += 1
+                        pending.append(
+                            Pending(
+                                pr,
+                                harvest,
+                                assessment,
+                                pr.head_sha,
+                                time.monotonic(),
+                                recreated=True,
+                            )
+                        )
+                        continue
+                    log.info("%s: not recreating — %s", pr.slug, why)
+
                 result.decisions.append(
                     Decision(
                         repo=pr.repo,

--- a/dependabot-triage/gh.py
+++ b/dependabot-triage/gh.py
@@ -100,11 +100,28 @@ def list_open_prs(repo: str, owner: str) -> list[dict[str, Any]]:
             "--limit",
             "100",
             "--json",
-            "number,title,author,baseRefName,headRefOid,labels,files,"
+            "number,title,author,baseRefName,headRefName,headRefOid,labels,files,"
             "mergeable,mergeStateStatus,body,createdAt",
         ]
     )
     return json.loads(raw) if raw.strip() else []
+
+
+def pr_commit_authors(repo: str, owner: str, number: int) -> list[str]:
+    """Logins of everyone who committed to the PR branch.
+
+    Needed before asking Dependabot to recreate: recreate force-pushes the
+    branch from scratch, which would silently discard any human fix-up commits.
+    Over 90 days, 30 merged Dependabot PRs carried exactly that kind of work.
+    """
+    raw = _run(["pr", "view", str(number), "--repo", f"{owner}/{repo}", "--json", "commits"])
+    data = json.loads(raw) if raw.strip() else {}
+    out: list[str] = []
+    for commit in data.get("commits", []):
+        for author in commit.get("authors") or []:
+            if author.get("login"):
+                out.append(author["login"])
+    return out
 
 
 def pr_diff(repo: str, owner: str, number: int) -> str:

--- a/dependabot-triage/harvest.py
+++ b/dependabot-triage/harvest.py
@@ -183,6 +183,7 @@ def harvest_repo(
                 author=author,
                 base_ref=raw.get("baseRefName", base),
                 head_sha=raw.get("headRefOid", ""),
+                head_ref=raw.get("headRefName", ""),
                 files=files,
                 labels=labels,
                 checks=checks,

--- a/dependabot-triage/models.py
+++ b/dependabot-triage/models.py
@@ -101,6 +101,7 @@ class PullRequest:
     author: str
     base_ref: str
     head_sha: str
+    head_ref: str = ""
     files: list[ChangedFile] = field(default_factory=list)
     labels: list[str] = field(default_factory=list)
     checks: list[CheckRun] = field(default_factory=list)

--- a/dependabot-triage/remediate.py
+++ b/dependabot-triage/remediate.py
@@ -1,0 +1,101 @@
+"""Deciding when a red Dependabot PR is worth asking Dependabot to rebuild.
+
+Some Dependabot PRs arrive red through no fault of the dependency being bumped.
+The dominant case in this org is a lockfile that disagrees with its manifest —
+`npm ci` refuses before a single test or lint rule runs, and the job that fails
+is often named after the thing it never got to (`lint-frontend`), which makes
+the failure look like something it isn't.
+
+Asking Dependabot to `recreate` rebuilds the branch from scratch against current
+base and regenerates the lockfile. That costs nothing here and needs no new
+capability: Dependabot does the work under its own identity, and this agent
+still never writes a file.
+
+The important constraint is that **recreate force-pushes**. Any human commit on
+the branch is destroyed. Across 90 days, 30 merged Dependabot PRs carried real
+human fix-up work, so a recreate that ignored authorship would eventually throw
+away someone's afternoon.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from models import PullRequest
+
+log = logging.getLogger(__name__)
+
+DEPENDABOT_LOGINS = frozenset({"dependabot", "dependabot[bot]", "app/dependabot"})
+
+# Failure signatures that a rebuild plausibly fixes: the manifest and the lock
+# disagree, or resolution was attempted against a stale tree. Anything caused by
+# the new version itself will simply fail again, so the list is deliberately
+# narrow rather than "any red PR".
+RECOVERABLE_SIGNATURES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"can only install packages when your package\.json and", re.I),
+        "npm lockfile out of sync with package.json",
+    ),
+    (re.compile(r"Missing: .+ from lock file", re.I), "package missing from lockfile"),
+    (re.compile(r"npm error code EUSAGE", re.I), "npm ci usage error (lock desync)"),
+    (
+        re.compile(r"lock file.{0,40}(out of date|does not match|is not up to date)", re.I),
+        "lockfile stale relative to manifest",
+    ),
+    (re.compile(r"ERROR: ResolutionImpossible", re.I), "pip could not resolve the tree"),
+    (
+        re.compile(r"poetry\.lock is not consistent with pyproject\.toml", re.I),
+        "poetry lockfile inconsistent",
+    ),
+)
+
+# Signatures that mean the bump itself is the problem. A rebuild cannot help and
+# would burn a full CI cycle — 20-30 minutes on the largest repo here.
+UNRECOVERABLE_SIGNATURES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"Test Suites?:.*failed", re.I),
+    re.compile(r"\d+ (?:test|spec)s? failed", re.I),
+    re.compile(r"AssertionError", re.I),
+    re.compile(r"error TS\d+", re.I),
+    re.compile(r"would be reformatted", re.I),
+    re.compile(r"found \d+ vulnerabilit", re.I),
+)
+
+
+def classify_failure(log_text: str) -> tuple[bool, str]:
+    """Return ``(recoverable_by_rebuild, human_readable_reason)``.
+
+    Unrecoverable signatures are checked first: a log can contain both, and a
+    genuine test failure is the more important fact.
+    """
+    if not log_text.strip():
+        return False, "no log available"
+    for pattern in UNRECOVERABLE_SIGNATURES:
+        if pattern.search(log_text):
+            return False, "failure looks caused by the update itself"
+    for pattern, reason in RECOVERABLE_SIGNATURES:
+        if pattern.search(log_text):
+            return True, reason
+    return False, "failure signature not recognised as recoverable"
+
+
+def has_human_commits(authors: list[str]) -> bool:
+    """True when anyone other than Dependabot has committed to the branch."""
+    return any(a and a not in DEPENDABOT_LOGINS for a in authors)
+
+
+def should_recreate(
+    pr: PullRequest,
+    required: frozenset[str],
+    log_text: str,
+    commit_authors: list[str],
+) -> tuple[bool, str]:
+    """Whether to ask Dependabot to rebuild this branch, and why not if not."""
+    if not pr.failing_required(required):
+        return False, "no required check is failing"
+    if has_human_commits(commit_authors):
+        return False, "branch carries human commits that a recreate would destroy"
+    recoverable, reason = classify_failure(log_text)
+    if not recoverable:
+        return False, reason
+    return True, reason

--- a/dependabot-triage/tests/test_remediate.py
+++ b/dependabot-triage/tests/test_remediate.py
@@ -1,0 +1,102 @@
+"""Tests for deciding when a red Dependabot PR is worth rebuilding.
+
+The motivating case: five BookshelfAI PRs failed a check named `lint-frontend`,
+which made them look like lint failures. They were `npm ci` refusing to run
+because the lockfile disagreed with package.json — nothing to do with linting,
+and not caused by the bump.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from conftest import REQUIRED, green_checks, make_pr  # noqa: E402
+
+import remediate  # noqa: E402
+from models import CheckRun  # noqa: E402
+
+NPM_DESYNC = """
+npm error code EUSAGE
+npm error `npm ci` can only install packages when your package.json and
+package-lock.json or npm-shrinkwrap.json are in sync.
+npm error Missing: react-native-worklets@0.8.3 from lock file
+"""
+PIP_UNRESOLVABLE = "ERROR: Cannot install -r requirements.txt\nERROR: ResolutionImpossible"
+REAL_TEST_FAILURE = """
+FAIL src/components/Card.test.tsx
+  * renders the title
+    AssertionError: expected 'a' to equal 'b'
+Test Suites: 1 failed, 12 passed
+"""
+LINT_FAILURE = "would be reformatted: src/index.ts\nOh no! 1 file would be reformatted."
+
+
+def red_pr(**kw):
+    checks = green_checks()[:-1] + [CheckRun(name=sorted(REQUIRED)[-1], conclusion="FAILURE")]
+    return make_pr(checks=checks, **kw)
+
+
+@pytest.mark.parametrize("text", [NPM_DESYNC, PIP_UNRESOLVABLE])
+def test_lockfile_desyncs_are_recoverable_by_a_rebuild(text):
+    recoverable, reason = remediate.classify_failure(text)
+    assert recoverable, reason
+
+
+@pytest.mark.parametrize("text", [REAL_TEST_FAILURE, LINT_FAILURE])
+def test_failures_caused_by_the_update_are_not_recoverable(text):
+    """A rebuild cannot fix these and would burn a full CI cycle."""
+    assert not remediate.classify_failure(text)[0]
+
+
+def test_a_real_test_failure_wins_over_a_desync_line_in_the_same_log():
+    """Logs can contain both; the genuine failure is the more important fact."""
+    assert not remediate.classify_failure(NPM_DESYNC + REAL_TEST_FAILURE)[0]
+
+
+def test_empty_log_is_not_treated_as_recoverable():
+    recoverable, reason = remediate.classify_failure("   ")
+    assert not recoverable and "no log" in reason
+
+
+def test_unrecognised_failure_is_left_alone():
+    recoverable, reason = remediate.classify_failure("Segmentation fault (core dumped)")
+    assert not recoverable and "not recognised" in reason
+
+
+@pytest.mark.parametrize("authors", [["dependabot[bot]"], ["app/dependabot", "dependabot"], []])
+def test_dependabot_only_branches_have_no_human_commits(authors):
+    assert not remediate.has_human_commits(authors)
+
+
+def test_a_human_commit_is_detected():
+    assert remediate.has_human_commits(["dependabot[bot]", "wcmchenry3-stack"])
+
+
+def test_human_commits_block_recreate_even_on_a_clean_desync():
+    """90 days of history had 30 PRs carrying real human fix-up commits."""
+    ok, why = remediate.should_recreate(
+        red_pr(), REQUIRED, NPM_DESYNC, ["dependabot[bot]", "wcmchenry3-stack"]
+    )
+    assert not ok
+    assert "human commits" in why
+
+
+def test_recreates_a_dependabot_only_desync():
+    ok, why = remediate.should_recreate(red_pr(), REQUIRED, NPM_DESYNC, ["dependabot[bot]"])
+    assert ok and "lock" in why
+
+
+def test_does_not_recreate_when_nothing_is_failing():
+    ok, why = remediate.should_recreate(make_pr(), REQUIRED, NPM_DESYNC, ["dependabot[bot]"])
+    assert not ok and "no required check is failing" in why
+
+
+def test_does_not_recreate_a_genuine_test_failure():
+    assert not remediate.should_recreate(
+        red_pr(), REQUIRED, REAL_TEST_FAILURE, ["dependabot[bot]"]
+    )[0]


### PR DESCRIPTION
## Summary

**The "linting" failures were not lint.** Five BookshelfAI PRs failed a check named `lint-frontend`, which is exactly why they looked like lint. The job was dying at `npm ci`:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json are in sync.
npm error Missing: react-native-worklets@0.8.3 from lock file
```

Before a single lint rule ran. A lint autofixer would have fixed **none** of them.

Asking Dependabot to `recreate` rebuilds the branch against current base and regenerates the lockfile. **No new capability** — Dependabot does the work under its own identity, and the agent still never writes a file.

## What makes it safe

**Recreate force-pushes.** Any human commit on the branch is destroyed. Across 90 days, **30 merged Dependabot PRs carried real human fix-up work**. Authorship is checked first, and any human commit refuses the rebuild outright — the alternative is eventually throwing away someone's afternoon.

**A rebuild can't fix a failure caused by the update itself**, and would burn a full CI cycle — 20–30 minutes on BC-Arcade. So signatures are matched explicitly rather than "retry anything red":

| Recoverable | Not recoverable |
|---|---|
| npm lock/manifest desync | test failures |
| `Missing: X from lock file` | `error TS####` |
| pip `ResolutionImpossible` | lint / formatting |
| poetry lock inconsistent | vulnerability findings |

Unrecoverable signatures are checked **first**, so a log containing both is judged on the genuine failure. Unrecognised failures are left alone. Capped at 4 rebuilds per run.

## A real bug found while building this

`diagnose` fetched the **repository's** most recent workflow run, not the **pull request's**:

```python
gh run list --repo X --limit 1        # ← whatever ran last, any branch
```

So a diagnosis could confidently describe an unrelated branch's failure and post it as a comment. Log fetching is now scoped to the PR's own head ref, and refuses to guess when the ref is unknown rather than reading something arbitrary.

## Test plan

- [x] 224 tests pass; `guards.py` still 100%
- [x] Tests cover: npm and pip desyncs recoverable; test/lint failures not; a log containing **both** judged unrecoverable; human commits blocking a rebuild
- [ ] Dry run: confirm it *would* rebuild the BookshelfAI PRs and would not touch anything with human commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dK1J2rJTka2kT4JFVX5Yn