### PR TITLE
feat(dependabot-triage): skip re-triaging PRs unchanged since their last verdict

### DIFF
--- a/dependabot-triage/__main__.py
+++ b/dependabot-triage/__main__.py
@@ -257,9 +257,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         report_mod.send(
             body,
-            report_mod.subject_line(
-                stats, config, now, dry_run=args.dry_run, repeats=len(repeats)
-            ),
+            report_mod.subject_line(stats, config, now, dry_run=args.dry_run, repeats=len(repeats)),
             config,
             suppress=args.no_email,
         )

--- a/dependabot-triage/__main__.py
+++ b/dependabot-triage/__main__.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import yaml
 
 import assess as assess_mod
+import dedupe as dedupe_mod
 import diagnose as diagnose_mod
 import execute as execute_mod
 import gh
@@ -28,7 +29,7 @@ import metrics
 import report as report_mod
 from budget import Budget, BudgetExceeded
 from llm import Client, ModelResponseInvalid
-from models import Action
+from models import Action, Repeat
 
 HERE = Path(__file__).parent
 log = logging.getLogger("triage")
@@ -36,6 +37,23 @@ log = logging.getLogger("triage")
 
 def load_config(path: Path) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _repeats_ledger(repeats: list[Repeat]) -> list[dict]:
+    return [
+        {
+            "repo": r.repo,
+            "number": r.number,
+            "title": r.title,
+            "tier": r.tier.value,
+            "action": r.action.value,
+            "reason": r.reason,
+            "deciding_question": r.deciding_question,
+            "last_seen_at": r.last_seen_at,
+            "last_run_id": r.last_run_id,
+        }
+        for r in repeats
+    ]
 
 
 def check_tripwires(harvests: list[harvest_mod.RepoHarvest], owner: str) -> list[str]:
@@ -189,16 +207,81 @@ def main(argv: list[str] | None = None) -> int:
 
     log.info("%d open Dependabot PR(s) across %d repo(s)", len(open_prs), len(harvests))
 
+    # --- Phase 1.5 ---------------------------------------------------------
+    # Drop PRs that already got a final "left for review" verdict and have not
+    # moved their head SHA since — see dedupe.py. Guard-blocked and deferred
+    # PRs are never dropped this way; only genuine, unchanged human-review
+    # holds are.
+    filtered_harvests, repeats = dedupe_mod.split(harvests, config)
+    new_open_prs = [pr for h in filtered_harvests for pr in h.dependabot_prs]
+
+    if not new_open_prs:
+        log.info(
+            "all %d open Dependabot PR(s) already triaged and unchanged; skipping model calls",
+            len(open_prs),
+        )
+        stats = metrics.summarise([])
+        args.ledger.parent.mkdir(parents=True, exist_ok=True)
+        args.ledger.write_text(
+            json.dumps(
+                {
+                    "run_id": args.run_id,
+                    "at": now.isoformat(),
+                    "dry_run": args.dry_run,
+                    "aborted": "",
+                    "stats": stats,
+                    "budget": budget.summary(),
+                    "decisions": [],
+                    "repeats": _repeats_ledger(repeats),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        body = report_mod.render_html(
+            summary=(
+                f"No new Dependabot activity tonight — {len(repeats)} pull request(s) already "
+                "triaged in a previous run and unchanged since; see below for what was said "
+                "last time."
+            ),
+            decisions=[],
+            stats=stats,
+            rolling=metrics.rolling(now=now),
+            precision=metrics.precision(now=now),
+            budget=budget.summary(),
+            run_url=args.run_url,
+            when=now,
+            dry_run=args.dry_run,
+            repeats=repeats,
+        )
+        report_mod.send(
+            body,
+            report_mod.subject_line(
+                stats, config, now, dry_run=args.dry_run, repeats=len(repeats)
+            ),
+            config,
+            suppress=args.no_email,
+        )
+        return 0
+
+    if repeats:
+        log.info(
+            "%d new/changed PR(s), %d already triaged and unchanged",
+            len(new_open_prs),
+            len(repeats),
+        )
+
     client = Client(budget, dry_run=args.dry_run)
     result = execute_mod.ExecutionResult()
 
     try:
         # --- Phase 2 -----------------------------------------------------
-        assessments = assess_mod.assess(harvests, client, config)
+        assessments = assess_mod.assess(filtered_harvests, client, config)
 
         # --- Phase 3 -----------------------------------------------------
         result = execute_mod.execute(
-            harvests,
+            filtered_harvests,
             assessments,
             client,
             config,
@@ -207,7 +290,7 @@ def main(argv: list[str] | None = None) -> int:
         )
 
         # --- Phase 4 -----------------------------------------------------
-        by_repo = {h.repo: h for h in harvests}
+        by_repo = {h.repo: h for h in filtered_harvests}
         for decision in result.decisions:
             if decision.merged or decision.action is Action.MERGE:
                 continue
@@ -282,6 +365,7 @@ def main(argv: list[str] | None = None) -> int:
                     }
                     for d in result.decisions
                 ],
+                "repeats": _repeats_ledger(repeats),
             },
             indent=2,
             sort_keys=True,
@@ -303,10 +387,13 @@ def main(argv: list[str] | None = None) -> int:
         when=now,
         dry_run=args.dry_run,
         aborted=aborted,
+        repeats=repeats,
     )
     report_mod.send(
         body,
-        report_mod.subject_line(stats, config, now, aborted=aborted, dry_run=args.dry_run),
+        report_mod.subject_line(
+            stats, config, now, aborted=aborted, dry_run=args.dry_run, repeats=len(repeats)
+        ),
         config,
         suppress=args.no_email,
     )

--- a/dependabot-triage/config.yml
+++ b/dependabot-triage/config.yml
@@ -109,6 +109,17 @@ remediate:
   enabled: true
   max_recreates_per_run: 4
 
+# Skip a PR that already received a "left for review" verdict in a previous
+# run and has not moved its head SHA since — no new commit means no new
+# information, so re-running the model and re-commenting would just restate
+# what was already said. A PR rejoins full triage the instant Dependabot (or
+# a human) pushes a new commit. Guard-blocked (SKIP) and deferred PRs are
+# never skipped this way — their eligibility depends on live CI/guard state
+# that can change without a new commit, and remediate's recreate-and-retry
+# loop needs to keep trying them.
+dedupe:
+  enabled: true
+
 # Per-PR kill switch.
 hold_label: "dependabot-triage:hold"
 

--- a/dependabot-triage/dedupe.py
+++ b/dependabot-triage/dedupe.py
@@ -1,0 +1,73 @@
+"""Phase 1.5 — drop PRs that already received a final verdict and have not changed since.
+
+Sits between harvest and assess. A PR that got a COMMENT verdict last night
+(left for a human to look at) and has not moved its head SHA carries no new
+information for the model to react to — reassessing it burns tokens and files
+an identical "left for review" comment on top of the one already there.
+
+Guard-blocked (SKIP) and deferred PRs are deliberately never deduped here:
+their eligibility depends on live CI/guard state that can change without a new
+commit (a rerun, a fix landing elsewhere), and remediate's recreate-and-retry
+loop depends on being tried again every run. Only a genuine "a human needs to
+look at this, and nothing new has arrived" verdict is treated as a repeat.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import metrics
+from harvest import RepoHarvest
+from models import Action, PullRequest, Repeat, RiskTier
+
+
+def _is_repeat(pr: PullRequest, last: dict | None) -> bool:
+    """True when ``last`` is a final COMMENT verdict already delivered on this exact commit."""
+    if not last or not pr.head_sha:
+        return False
+    if last.get("head_sha") != pr.head_sha:
+        return False
+    if last.get("deferred"):
+        return False
+    return last.get("action") == Action.COMMENT.value
+
+
+def _to_repeat(pr: PullRequest, last: dict) -> Repeat:
+    at = last.get("at") or ""
+    return Repeat(
+        repo=pr.repo,
+        number=pr.number,
+        title=pr.title,
+        tier=RiskTier(last.get("tier", RiskTier.MEDIUM.value)),
+        action=Action(last.get("action", Action.COMMENT.value)),
+        reason=last.get("reason", ""),
+        deciding_question=last.get("deciding_question", ""),
+        head_sha=pr.head_sha,
+        last_seen_at=at[:10],
+        last_run_id=str(last.get("run_id", "")),
+    )
+
+
+def split(harvests: list[RepoHarvest], config: dict) -> tuple[list[RepoHarvest], list[Repeat]]:
+    """Partition harvested PRs into ones that still need triage and repeats.
+
+    Returns a new list of :class:`RepoHarvest` with repeat PRs removed from
+    ``prs`` — the harvests passed in are left untouched — plus the repeats
+    themselves, each carrying the verdict and date they were last given.
+    """
+    if not config.get("dedupe", {}).get("enabled", True):
+        return harvests, []
+
+    last_by_slug = metrics.last_decisions()
+    filtered: list[RepoHarvest] = []
+    repeats: list[Repeat] = []
+    for harvest in harvests:
+        kept: list[PullRequest] = []
+        for pr in harvest.dependabot_prs:
+            last = last_by_slug.get(pr.slug)
+            if _is_repeat(pr, last):
+                repeats.append(_to_repeat(pr, last))
+            else:
+                kept.append(pr)
+        filtered.append(replace(harvest, prs=kept))
+    return filtered, repeats

--- a/dependabot-triage/execute.py
+++ b/dependabot-triage/execute.py
@@ -157,6 +157,7 @@ def execute(
                         action=Action.COMMENT,
                         reason=assessment.rationale,
                         deciding_question=assessment.deciding_question,
+                        head_sha=pr.head_sha,
                     )
                 )
                 continue
@@ -213,6 +214,7 @@ def execute(
                         reason="Automated merge refused by a precondition check.",
                         guard_results=checks,
                         deciding_question=assessment.deciding_question,
+                        head_sha=pr.head_sha,
                     )
                 )
                 continue
@@ -230,6 +232,7 @@ def execute(
                         action=Action.COMMENT,
                         reason=f"Downgraded on adversarial review: {objection}",
                         deciding_question=assessment.deciding_question,
+                        head_sha=pr.head_sha,
                     )
                 )
                 continue
@@ -261,6 +264,7 @@ def execute(
                         action=Action.SKIP,
                         reason=f"Per-repo merge cap of {caps['max_merges_per_repo']} reached.",
                         deferred=True,
+                        head_sha=item.pr.head_sha,
                     )
                 )
                 continue
@@ -289,6 +293,7 @@ def execute(
                             reason="Dependabot did not land a rebase in time; deferred to the next run.",
                             deferred=True,
                             rebased=True,
+                            head_sha=fresh.head_sha,
                         )
                     )
                     progressed = True
@@ -307,6 +312,7 @@ def execute(
                             action=Action.COMMENT,
                             reason="CI had not finished within the wait budget; deferred to the next run.",
                             deferred=True,
+                            head_sha=fresh.head_sha,
                         )
                     )
                     progressed = True
@@ -328,6 +334,7 @@ def execute(
                             "original low-risk assessment no longer applies. Left for review."
                         ),
                         rebased=True,
+                        head_sha=fresh.head_sha,
                     )
                 )
                 continue
@@ -356,6 +363,7 @@ def execute(
                         reason="Preconditions no longer held at merge time.",
                         guard_results=checks,
                         rebased=bool(item.original_sha),
+                        head_sha=fresh.head_sha,
                     )
                 )
                 continue
@@ -373,6 +381,7 @@ def execute(
                     guard_results=checks,
                     rebased=bool(item.original_sha),
                     merged=True,
+                    head_sha=fresh.head_sha,
                 )
             )
 
@@ -391,6 +400,7 @@ def execute(
                 action=Action.COMMENT,
                 reason="Run reached its wall-clock budget; deferred to the next run.",
                 deferred=True,
+                head_sha=item.pr.head_sha,
             )
         )
 

--- a/dependabot-triage/metrics.py
+++ b/dependabot-triage/metrics.py
@@ -73,6 +73,7 @@ def record_run(
                     "deciding_question": decision.deciding_question,
                     "failed_guard": decision.failed_guard,
                     "reason": decision.reason,
+                    "head_sha": decision.head_sha,
                     "guards": _guard_summary(decision),
                 },
                 sort_keys=True,
@@ -155,6 +156,25 @@ def load_history(since: datetime | None = None) -> list[dict]:
                     continue
             entries.append(entry)
     return entries
+
+
+def last_decisions() -> dict[str, dict]:
+    """Most recent decision entry recorded for each PR, across all history.
+
+    History files are append-only and read in chronological order (by month
+    file name, then by line), so simply overwriting per slug as entries are
+    walked leaves the latest one behind — same assumption ``rolling`` and
+    ``precision`` already rely on.
+
+    Used by dedupe.py to recognise a PR that already received a verdict on
+    its current head SHA, so a run can skip re-triaging it.
+    """
+    out: dict[str, dict] = {}
+    for entry in load_history():
+        if entry.get("type") != "decision":
+            continue
+        out[f"{entry.get('repo')}#{entry.get('number')}"] = entry
+    return out
 
 
 def rolling(days: int = 30, now: datetime | None = None) -> dict:

--- a/dependabot-triage/models.py
+++ b/dependabot-triage/models.py
@@ -187,6 +187,10 @@ class Decision:
     # PR was never mergeable tonight by anyone, so counting it against the agent
     # would make the autonomy rate measure repo health rather than agent behaviour.
     pre_existing_red: bool = False
+    # The commit this decision was made on. Recorded to history so a future run
+    # can recognise "this exact PR, unchanged" and skip re-triaging it — see
+    # dedupe.py.
+    head_sha: str = ""
 
     @property
     def slug(self) -> str:
@@ -198,3 +202,29 @@ class Decision:
             if not g.passed:
                 return g.guard_id
         return ""
+
+
+@dataclass(frozen=True)
+class Repeat:
+    """An open PR carried over from a previous run because nothing changed.
+
+    Built by dedupe.py from the most recent matching history entry when a PR's
+    head SHA is unchanged since it last received a final, non-deferred COMMENT
+    verdict. Never re-assessed, never re-commented — just surfaced in the
+    report so the previous verdict stays visible without being repeated.
+    """
+
+    repo: str
+    number: int
+    title: str
+    tier: RiskTier
+    action: Action
+    reason: str
+    deciding_question: str
+    head_sha: str
+    last_seen_at: str
+    last_run_id: str
+
+    @property
+    def slug(self) -> str:
+        return f"{self.repo}#{self.number}"

--- a/dependabot-triage/report.py
+++ b/dependabot-triage/report.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from pathlib import Path
 
 from llm import Client
-from models import Action, Decision, RiskTier
+from models import Action, Decision, Repeat, RiskTier
 
 log = logging.getLogger(__name__)
 
@@ -90,6 +90,26 @@ def _decision_row(decision: Decision, run_url: str) -> str:
     )
 
 
+def _repeat_row(r: Repeat) -> str:
+    # One flat table spans every repo (unlike the per-repo decision sections
+    # above it), so each row names its own repo rather than relying on a
+    # shared heading.
+    tier_colour, tier_label = TIER_BADGE[r.tier]
+    ref = f"{_esc(r.repo)}#{r.number}"
+    reason = _esc(r.reason)
+    if r.deciding_question and r.deciding_question != "NONE":
+        reason += f' <span style="color:#57606a">({_esc(r.deciding_question)})</span>'
+    return (
+        "<tr>"
+        f'<td style="padding:6px 10px;white-space:nowrap"><code>{ref}</code></td>'
+        f'<td style="padding:6px 10px">{_esc(r.title)}</td>'
+        f'<td style="padding:6px 10px;white-space:nowrap;color:{tier_colour};font-weight:600">{tier_label}</td>'
+        f'<td style="padding:6px 10px;color:#57606a">{reason}</td>'
+        f'<td style="padding:6px 10px;white-space:nowrap;color:#57606a">since {_esc(r.last_seen_at)}</td>'
+        "</tr>"
+    )
+
+
 def render_html(
     *,
     summary: str,
@@ -102,8 +122,10 @@ def render_html(
     when: datetime,
     dry_run: bool,
     aborted: str = "",
+    repeats: list[Repeat] | None = None,
 ) -> str:
     """Build the email body. Pure function over the ledger — no I/O, no model."""
+    repeats = repeats or []
     by_repo: dict[str, list[Decision]] = {}
     for decision in decisions:
         by_repo.setdefault(decision.repo, []).append(decision)
@@ -127,6 +149,8 @@ def render_html(
         f'{stats["seen"] - stats["merged"] - stats["blocked_by_guard"]} left for review · '
         f'<span style="color:#cf222e">{stats["blocked_by_guard"]} refused</span>'
     )
+    if repeats:
+        head += f' · <span style="color:#57606a">{len(repeats)} unchanged</span>'
 
     sections: list[str] = []
     for repo in sorted(by_repo):
@@ -140,8 +164,18 @@ def render_html(
             '<table style="border-collapse:collapse;width:100%;font-size:13px">'
             f"{rows}</table>"
         )
-    if not sections:
+    if not sections and not repeats:
         sections.append('<p style="color:#57606a">No open Dependabot pull requests.</p>')
+
+    if repeats:
+        repeat_rows = "".join(_repeat_row(r) for r in repeats)
+        sections.append(
+            '<h3 style="margin:22px 0 6px;font-size:15px;color:#57606a">Already triaged '
+            f'<span style="font-weight:400">— {len(repeats)} PR(s) unchanged since a previous '
+            'run, not re-reviewed tonight</span></h3>'
+            '<table style="border-collapse:collapse;width:100%;font-size:13px">'
+            f"{repeat_rows}</table>"
+        )
 
     return f"""<!doctype html>
 <html><body style="font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;
@@ -224,17 +258,20 @@ def send(html_body: str, subject: str, config: dict, *, suppress: bool = False) 
 
 
 def subject_line(
-    stats: dict, config: dict, when: datetime, aborted: str = "", dry_run: bool = False
+    stats: dict,
+    config: dict,
+    when: datetime,
+    aborted: str = "",
+    dry_run: bool = False,
+    repeats: int = 0,
 ) -> str:
     prefix = config["report"]["subject_prefix"]
     if dry_run:
         prefix = f"[DRY RUN] {prefix}"
     if aborted:
         return f"{prefix} — ABORTED — {when:%a %d %b}"
-    return (
-        f"{prefix} — {stats['merged']} would merge, "
-        f"{stats['seen'] - stats['merged']} pending — {when:%a %d %b}"
-        if dry_run
-        else f"{prefix} — {stats['merged']} merged, "
-        f"{stats['seen'] - stats['merged']} pending — {when:%a %d %b}"
-    )
+    verb = "would merge" if dry_run else "merged"
+    subject = f"{prefix} — {stats['merged']} {verb}, {stats['seen'] - stats['merged']} pending"
+    if repeats:
+        subject += f", {repeats} unchanged"
+    return f"{subject} — {when:%a %d %b}"

--- a/dependabot-triage/report.py
+++ b/dependabot-triage/report.py
@@ -172,7 +172,7 @@ def render_html(
         sections.append(
             '<h3 style="margin:22px 0 6px;font-size:15px;color:#57606a">Already triaged '
             f'<span style="font-weight:400">— {len(repeats)} PR(s) unchanged since a previous '
-            'run, not re-reviewed tonight</span></h3>'
+            "run, not re-reviewed tonight</span></h3>"
             '<table style="border-collapse:collapse;width:100%;font-size:13px">'
             f"{repeat_rows}</table>"
         )

--- a/dependabot-triage/tests/test_dedupe.py
+++ b/dependabot-triage/tests/test_dedupe.py
@@ -34,14 +34,16 @@ def _record(monkeypatch, tmp_path, **decision_kwargs) -> None:
         "head_sha": "a" * 40,
     }
     defaults.update(decision_kwargs)
-    metrics_mod.record_run(
-        [Decision(**defaults)], {}, run_id="r1", now=NOW, dry_run=True
-    )
+    metrics_mod.record_run([Decision(**defaults)], {}, run_id="r1", now=NOW, dry_run=True)
 
 
 def _harvest(pr) -> RepoHarvest:
     return RepoHarvest(
-        repo="buffingchi_site", base="dev", merge_method="squash", baseline=make_baseline(), prs=[pr]
+        repo="buffingchi_site",
+        base="dev",
+        merge_method="squash",
+        baseline=make_baseline(),
+        prs=[pr],
     )
 
 

--- a/dependabot-triage/tests/test_dedupe.py
+++ b/dependabot-triage/tests/test_dedupe.py
@@ -1,0 +1,136 @@
+"""Tests for the repeat-detection phase between harvest and assess.
+
+A repeat is only ever a *previous, unchanged, non-deferred COMMENT verdict* —
+everything else (a new commit, a first-time PR, a deferred decision, or a
+guard-blocked SKIP) must still go through full triage. See dedupe.py for why
+SKIP and deferred decisions are excluded on purpose.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from conftest import make_baseline, make_pr
+
+import dedupe as dedupe_mod
+import metrics as metrics_mod
+from harvest import RepoHarvest
+from models import Action, Decision, RiskTier
+
+NOW = datetime(2026, 8, 15, 6, 0, tzinfo=UTC)
+
+CONFIG = {"dedupe": {"enabled": True}}
+
+
+def _record(monkeypatch, tmp_path, **decision_kwargs) -> None:
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    defaults = {
+        "repo": "buffingchi_site",
+        "number": 101,
+        "title": "chore(deps): bump lodash from 4.17.20 to 4.17.21",
+        "tier": RiskTier.HIGH,
+        "action": Action.COMMENT,
+        "reason": "Major version bump, needs a human look.",
+        "head_sha": "a" * 40,
+    }
+    defaults.update(decision_kwargs)
+    metrics_mod.record_run(
+        [Decision(**defaults)], {}, run_id="r1", now=NOW, dry_run=True
+    )
+
+
+def _harvest(pr) -> RepoHarvest:
+    return RepoHarvest(
+        repo="buffingchi_site", base="dev", merge_method="squash", baseline=make_baseline(), prs=[pr]
+    )
+
+
+def test_unchanged_comment_verdict_is_deduped_as_a_repeat(tmp_path, monkeypatch):
+    _record(monkeypatch, tmp_path, head_sha="a" * 40)
+    pr = make_pr(head_sha="a" * 40)
+
+    filtered, repeats = dedupe_mod.split([_harvest(pr)], CONFIG)
+
+    assert filtered[0].dependabot_prs == []
+    assert [r.slug for r in repeats] == ["buffingchi_site#101"]
+    assert repeats[0].tier is RiskTier.HIGH
+    assert repeats[0].reason == "Major version bump, needs a human look."
+    assert repeats[0].last_run_id == "r1"
+    assert repeats[0].last_seen_at == "2026-08-15"
+
+
+def test_new_head_sha_is_not_deduped(tmp_path, monkeypatch):
+    _record(monkeypatch, tmp_path, head_sha="a" * 40)
+    pr = make_pr(head_sha="b" * 40)  # rebased since the last verdict
+
+    filtered, repeats = dedupe_mod.split([_harvest(pr)], CONFIG)
+
+    assert [p.number for p in filtered[0].dependabot_prs] == [101]
+    assert repeats == []
+
+
+def test_pr_with_no_prior_decision_is_not_deduped(tmp_path, monkeypatch):
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    pr = make_pr()
+
+    filtered, repeats = dedupe_mod.split([_harvest(pr)], CONFIG)
+
+    assert [p.number for p in filtered[0].dependabot_prs] == [101]
+    assert repeats == []
+
+
+def test_deferred_decision_is_not_deduped(tmp_path, monkeypatch):
+    """A deferred verdict is explicitly meant to be retried, not repeated as final."""
+    _record(monkeypatch, tmp_path, head_sha="a" * 40, deferred=True)
+    pr = make_pr(head_sha="a" * 40)
+
+    filtered, repeats = dedupe_mod.split([_harvest(pr)], CONFIG)
+
+    assert [p.number for p in filtered[0].dependabot_prs] == [101]
+    assert repeats == []
+
+
+def test_skip_decision_is_not_deduped(tmp_path, monkeypatch):
+    """Guard-blocked PRs always retry — their eligibility can change without a new commit."""
+    _record(monkeypatch, tmp_path, head_sha="a" * 40, action=Action.SKIP, tier=RiskTier.LOW)
+    pr = make_pr(head_sha="a" * 40)
+
+    filtered, repeats = dedupe_mod.split([_harvest(pr)], CONFIG)
+
+    assert [p.number for p in filtered[0].dependabot_prs] == [101]
+    assert repeats == []
+
+
+def test_dedupe_disabled_is_a_pass_through(tmp_path, monkeypatch):
+    _record(monkeypatch, tmp_path, head_sha="a" * 40)
+    pr = make_pr(head_sha="a" * 40)
+    harvests = [_harvest(pr)]
+
+    filtered, repeats = dedupe_mod.split(harvests, {"dedupe": {"enabled": False}})
+
+    assert filtered is harvests
+    assert repeats == []
+
+
+def test_last_decisions_returns_the_most_recent_entry_per_pr(tmp_path, monkeypatch):
+    monkeypatch.setattr(metrics_mod, "HISTORY_DIR", tmp_path)
+    metrics_mod.record_run(
+        [Decision("r", 1, "t", RiskTier.HIGH, Action.COMMENT, "first look", head_sha="a" * 40)],
+        {},
+        run_id="r1",
+        now=NOW,
+        dry_run=True,
+    )
+    metrics_mod.record_run(
+        [Decision("r", 1, "t", RiskTier.MEDIUM, Action.COMMENT, "second look", head_sha="b" * 40)],
+        {},
+        run_id="r2",
+        now=datetime(2026, 8, 16, 6, 0, tzinfo=UTC),
+        dry_run=True,
+    )
+
+    last = metrics_mod.last_decisions()
+
+    assert last["r#1"]["head_sha"] == "b" * 40
+    assert last["r#1"]["reason"] == "second look"
+    assert last["r#1"]["run_id"] == "r2"

--- a/dependabot-triage/tests/test_pipeline.py
+++ b/dependabot-triage/tests/test_pipeline.py
@@ -18,7 +18,7 @@ import execute as execute_mod
 import harvest as harvest_mod
 import metrics as metrics_mod
 import report as report_mod
-from models import Action, Assessment, Decision, GuardResult, RiskTier
+from models import Action, Assessment, Decision, GuardResult, Repeat, RiskTier
 
 NOW = datetime(2026, 8, 15, 6, 0, tzinfo=UTC)
 
@@ -419,6 +419,45 @@ def test_empty_run_renders_without_error():
     assert "No open Dependabot pull requests" in _render([])
 
 
+def _repeat(**kw) -> Repeat:
+    defaults = {
+        "repo": "RulersAI",
+        "number": 663,
+        "title": "chore: bump actions/setup-python from 6 to 7",
+        "tier": RiskTier.MEDIUM,
+        "action": Action.COMMENT,
+        "reason": "Major version bump of a CI-only action; needs a human look.",
+        "deciding_question": "Q1_semver",
+        "head_sha": "a" * 40,
+        "last_seen_at": "2026-08-15",
+        "last_run_id": "31932336517",
+    }
+    defaults.update(kw)
+    return Repeat(**defaults)
+
+
+def test_repeats_render_as_a_distinct_already_triaged_block():
+    body = _render([], repeats=[_repeat()])
+    assert "Already triaged" in body
+    assert "RulersAI" in body
+    assert "since 2026-08-15" in body
+    assert "unchanged" in body
+
+
+def test_repeats_do_not_replace_the_no_open_prs_empty_state_when_both_are_empty():
+    assert "No open Dependabot pull requests" in _render([], repeats=[])
+
+
+def test_repeats_are_excluded_from_the_nights_stats():
+    """The whole point: an unchanged PR must not count toward tonight's tally."""
+    stats = metrics_mod.summarise([])  # only what execute() actually did tonight
+    assert stats["seen"] == 0
+    assert stats["autonomy_rate"] is None
+    # Rendering repeats alongside empty decisions must not touch that stats dict.
+    body = _render([], repeats=[_repeat(), _repeat(number=420, repo="BookshelfAI")])
+    assert "2 unchanged" in body
+
+
 def test_subject_line_summarises_the_night():
     stats = metrics_mod.summarise(
         [_decision(), _decision(number=2, merged=False, action=Action.COMMENT)]
@@ -426,6 +465,14 @@ def test_subject_line_summarises_the_night():
     config = {"report": {"subject_prefix": "Dependabot Triage"}}
     assert report_mod.subject_line(stats, config, NOW) == (
         "Dependabot Triage — 1 merged, 1 pending — Sat 15 Aug"
+    )
+
+
+def test_subject_line_notes_repeats_without_changing_the_pending_count():
+    stats = metrics_mod.summarise([_decision()])
+    config = {"report": {"subject_prefix": "Dependabot Triage"}}
+    assert report_mod.subject_line(stats, config, NOW, repeats=2) == (
+        "Dependabot Triage — 1 merged, 0 pending, 2 unchanged — Sat 15 Aug"
     )
 
 


### PR DESCRIPTION
## Summary

The nightly Dependabot triage agent re-harvests and re-assesses every open Dependabot PR each run, even ones that already received a final `COMMENT` (human-review) verdict the night before and haven't moved since — burning model tokens and posting a duplicate "left for review" comment on top of the one already there.

This tracks each decision's `head_sha` in history and skips re-triaging an open PR whose `head_sha` matches a previous, non-deferred `COMMENT` verdict:

- If **every** open PR is such a repeat, the run exits before any model call (same shape as the existing "no open PRs" fast path) and sends a quiet email acknowledging what was already said and when.
- If some PRs are new/changed and others are repeats, only the new ones go through full triage; the repeats are folded into the same report as a separate "Already triaged" section carrying the prior verdict — visible, but not counted toward tonight's stats or re-recorded to history.

**Deliberately out of scope:** guard-blocked (`SKIP`) and `deferred: true` decisions are never deduped, even with an unchanged `head_sha` — their eligibility depends on live CI/guard state that can change without a new commit, and `remediate`'s recreate-and-retry loop depends on being tried again every run.

## Changes

- `models.py` — `Decision` gains `head_sha`; new `Repeat` dataclass
- `execute.py` — thread `head_sha` through all 10 `Decision(...)` sites
- `metrics.py` — record `head_sha` to history; new `last_decisions()`
- `dedupe.py` *(new)* — phase 1.5, partitions harvested PRs into "needs triage" vs. repeats
- `__main__.py` — wires dedupe in between harvest and assess; new "all repeats" quiet path
- `report.py` — renders repeats as a distinct, uncounted section; subject line notes the count
- `config.yml` — `dedupe.enabled` kill switch (default `true`)

## Testing

```
python -m pytest tests -q                                                   # 235 passed, 86.63% (floor 80%)
python -m pytest tests -q -o addopts="" --cov=guards --cov-fail-under=100   # guard boundary still 100%
```

New `tests/test_dedupe.py` covers: unchanged-COMMENT dedup, new-SHA no-dedup, first-seen no-dedup, deferred no-dedup, SKIP no-dedup, the `dedupe.enabled: false` pass-through, and `metrics.last_decisions()` returning only the most recent entry per PR. `tests/test_pipeline.py` gained report-rendering tests for the new "Already triaged" section and the subject-line repeats count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)